### PR TITLE
mon.py: correctly handle boolean return values

### DIFF
--- a/apps/mon.py.in
+++ b/apps/mon.py.in
@@ -330,6 +330,9 @@ else:
 			args = rem_args
 
 	ret = commands[cmd](args)
-	if isinstance(ret, int):
+	if isinstance(ret, bool):
+		if ret == False:
+			sys.exit(1)
+	elif isinstance(ret, int):
 		sys.exit(ret)
 	sys.exit(0)


### PR DESCRIPTION
Earlier boolean output of "mon" command was not recognised in mon.py.in
file. so it was returning exit code .

Added code to check the boolean output of "mon" command.

This fixes issue MON-11302

Co-Authored-By: Jacob Hansen <jhansen@op5.com>
Signed-off-by: devesh thakur <dthakur@op5.com>