### PR TITLE
Fix logrotate version check for RHEL

### DIFF
--- a/data/merlin.in
+++ b/data/merlin.in
@@ -5,7 +5,7 @@
 	sharedscripts
 	missingok
 	postrotate
-		VERSION=$(awk -F= '/^VERSION_ID/ { print gensub(/\"([0-9]+).*/,"\\1","",$2) }' /etc/os-release)
+		VERSION=$(grep -h release /etc/*-release | uniq | awk '{print $(NF-1)}' | cut -d . -f 1)
 		if [[ "$VERSION" -ge 7 ]]; then
 			systemctl try-restart naemon > /dev/null 2>&1
 			systemctl try-restart merlind > /dev/null 2>&1

--- a/data/merlin.in
+++ b/data/merlin.in
@@ -5,7 +5,7 @@
 	sharedscripts
 	missingok
 	postrotate
-		VERSION=$(cat /etc/os-release|grep 'VERSION_ID'|awk -F"\"" '{print $2}')
+		VERSION=$(awk -F= '/^VERSION_ID/ { print gensub(/\"([0-9]+).*/,"\\1","",$2) }' /etc/os-release)
 		if [[ "$VERSION" -ge 7 ]]; then
 			systemctl try-restart naemon > /dev/null 2>&1
 			systemctl try-restart merlind > /dev/null 2>&1

--- a/data/merlin.in
+++ b/data/merlin.in
@@ -5,8 +5,7 @@
 	sharedscripts
 	missingok
 	postrotate
-		VERSION=$(grep -h release /etc/*-release | uniq | awk '{print $(NF-1)}' | cut -d . -f 1)
-		if [[ "$VERSION" -ge 7 ]]; then
+		if command -v systemctl &>/dev/null; then
 			systemctl try-restart naemon > /dev/null 2>&1
 			systemctl try-restart merlind > /dev/null 2>&1
 		else


### PR DESCRIPTION
This fixes MON-11632.

The previous way of checking the version number was failing on both
RHEL as well as EL6 (but here it only gave an error message, since the
logic allowed for it to fail and go to the else clause).

The above method works on both CentOS 6 and RHEL 7.

Signed-off-by: Johan Thorén <jthoren@op5.com>