### PR TITLE
Replace version check with command check

### DIFF
--- a/data/merlin.in
+++ b/data/merlin.in
@@ -5,8 +5,7 @@
 	sharedscripts
 	missingok
 	postrotate
-		VERSION=$(cat /etc/os-release|grep 'VERSION_ID'|awk -F"\"" '{print $2}')
-		if [[ "$VERSION" -ge 7 ]]; then
+		if command -v systemctl &>/dev/null; then
 			systemctl try-restart naemon > /dev/null 2>&1
 			systemctl try-restart merlind > /dev/null 2>&1
 		else


### PR DESCRIPTION
This fixes MON-11632.

Instead of trying to figure out what version of EL is running
by grepping text files, this now checks if the systemctl command
exists directly instead.

Signed-off-by: Johan Thoren <jthoren@op5.com>