### PR TITLE
Return exit code 1 if there are inactive nodes

### DIFF
--- a/apps/libexec/node.py
+++ b/apps/libexec/node.py
@@ -71,7 +71,7 @@ def cmd_status(args):
 
 	if not sinfo:
 		print("Found no checks")
-		return
+		return 1
 
 	host_checks = 0
 	service_checks = 0

--- a/apps/libexec/node.py
+++ b/apps/libexec/node.py
@@ -65,6 +65,7 @@ def cmd_status(args):
 	mentioned = {}
 	pg_oconf_hash = {}
 	pg_conf = {}
+	exit_code = 0
 
 	sinfo = list(get_merlin_nodeinfo(query_socket))
 
@@ -125,6 +126,7 @@ def cmd_status(args):
 			name += ": %sACTIVE%s - %s%.3fs%s latency" % (color.green, color.reset, lat_color, latency, color.reset)
 		else:
 			name += " (%sINACTIVE%s)" % (color.red, color.reset)
+			exit_code = 1
 
 		print("%s" % name)
 
@@ -248,6 +250,7 @@ def cmd_status(args):
 			print("  peer-group %d: %s" % (pg_id, ', '.join(bad)))
 		print("%sPlease ensure that all peered nodes share neighbours%s" %
 			(color.yellow, color.reset))
+	return exit_code
 
 
 ## node commands ##


### PR DESCRIPTION
Previously the 'mon node status' command would always exit with
exit code 0, regardless of whether there were any inactive
nodes in the listing or not.

This patch adds a new variable that is used to return exit
code 1 in the case where there is one or more inactive
nodes listed.