### PR TITLE
Fix sudoers rules for allowed mon commands

### DIFF
--- a/sudo/merlin.in
+++ b/sudo/merlin.in
@@ -2,11 +2,13 @@ Defaults:@naemon_user@ !requiretty
 @naemon_user@ ALL=(root) NOPASSWD:/usr/bin/mon restart
 @naemon_user@ ALL=(root) NOPASSWD:/usr/bin/op5 restart
 
-Cmnd_Alias      MON_OPERATOR =  /usr/bin/mon node status,\
-        /usr/bin/mon node list *,\
-        /usr/bin/mon node show *,\
-        /usr/bin/mon check exectime *,\
-        /usr/bin/mon check latency *,\
+Cmnd_Alias      MON_OPERATOR =  /usr/bin/mon node,\
+        /usr/bin/mon node status,\
+        /usr/bin/mon node list*,\
+        /usr/bin/mon node show*,\
+        /usr/bin/mon check,\
+        /usr/bin/mon check exectime*,\
+        /usr/bin/mon check latency*,\
         /usr/bin/mon check orphans,\
         /usr/bin/mon start,\
         /usr/bin/mon stop,\


### PR DESCRIPTION
Fix the issue that `mon node` and `mon check` commands only allowed use
with optional parameters, which was not intended. Also allow to run
`sudo mon node/check` to display usage text.

This fixes MON-11159