### PR TITLE
Create group during installation for sudoers use

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -21,6 +21,7 @@
 # re-define service_control_function to use el7 commands
 %define create_service_control_function function service_control_function () { systemctl $1 $2; };
 %endif
+%define operator_group mon_operators
 
 Summary: The merlin daemon is a multiplexing event-transport program
 Name: merlin
@@ -229,6 +230,9 @@ chown -R %daemon_user:%daemon_group %_localstatedir/cache/merlin
 for daemon in merlind nrpe; do
     service_control_function restart $daemon
 done
+
+# Create operator group for use in sudoers
+getent group %operator_group > /dev/null || groupadd %operator_group
 
 %preun -n monitor-merlin
 %create_service_control_function

--- a/sudo/merlin.in
+++ b/sudo/merlin.in
@@ -1,3 +1,17 @@
 Defaults:@naemon_user@ !requiretty
 @naemon_user@ ALL=(root) NOPASSWD:/usr/bin/mon restart
 @naemon_user@ ALL=(root) NOPASSWD:/usr/bin/op5 restart
+
+Cmnd_Alias      MON_OPERATOR =  /usr/bin/mon node,\
+        /usr/bin/mon node status,\
+        /usr/bin/mon node list*,\
+        /usr/bin/mon node show*,\
+        /usr/bin/mon check,\
+        /usr/bin/mon check exectime*,\
+        /usr/bin/mon check latency*,\
+        /usr/bin/mon check orphans,\
+        /usr/bin/mon start,\
+        /usr/bin/mon stop,\
+        /usr/bin/mon restart
+
+%mon_operators  ALL = (ALL) NOPASSWD: MON_OPERATOR


### PR DESCRIPTION
When installing the RPM package, create an user group for monitor
operators to be able to run certain `mon` commands as root.

This fixes MON-11159