### PR TITLE
Add lmd dependency and fix build on EL 7.7

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -108,6 +108,7 @@ network monitoring setup.
 Summary: Test files for merlin
 Group: op5/Monitor
 Requires: monitor-livestatus
+Requires: op5-lmd
 Requires: op5-naemon
 Requires: merlin merlin-apps monitor-merlin
 BuildRequires: diffutils

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -36,6 +36,12 @@ post:
     ulimit -c unlimited
     mkdir -p /mnt/logs
     echo "core ulimit: \$(ulimit -c)"
+
+    # Workaround for EL7.7 bug BZ#1731062 (https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.7_release_notes/known_issues)
+    if [ -f /usr/bin/systemctl ]; then
+      ln -s /usr/bin/resolveip /usr/libexec/resolveip
+    fi
+
     # skip systemd tests on EL6
     if [ -f /usr/bin/systemctl ]; then
       cucumber --strict --format html --out /mnt/logs/cucumber.html --format pretty


### PR DESCRIPTION
Add LMD dependency

As of Monitor 8, livestatus queries are made against LMD. To ensure all
integration tests works correct, we add LMD as a dependency to the
package.

------

Add workaround for EL7.7 bug related to MySQL

A known issue in EL7.7 causes issues with the mysql_install_db script
used during the tests. A workaround is added in the ci_config file.

More info can be found at section 8.7 on:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.7_release_notes/known_issues