### PR TITLE
Limit DEL_DOWNTIME_BY_HOST_NAME to relevant nodes

### DIFF
--- a/module/hooks.c
+++ b/module/hooks.c
@@ -687,6 +687,7 @@ static int hook_external_command(merlin_event *pkt, void *data)
 	case CMD_CHANGE_CONTACT_SVC_NOTIFICATION_TIMEPERIOD:
 	case CMD_CHANGE_HOST_MODATTR:
 	case CMD_CHANGE_SVC_MODATTR:
+	case CMD_DEL_DOWNTIME_BY_HOST_NAME:
 		/*
 		 * looks like we have everything we need, so get the
 		 * selection based on the hostname so the daemon knows


### PR DESCRIPTION
Prior to this commit the external command DEL_DOWNTIME_BY_HOST_NAME was
sent to all nodes. However we should not send this command to a poller,
if that poller isn't handling the host.

This is part of MON-9109

Signed-off-by: Jacob Hansen <jhansen@op5.com>