### PR TITLE
Limit DEL_DOWNTIME_BY_HOST_NAME to relevant nodes (7.5)

### DIFF
--- a/module/hooks.c
+++ b/module/hooks.c
@@ -687,6 +687,7 @@ static int hook_external_command(merlin_event *pkt, void *data)
 	case CMD_CHANGE_CONTACT_SVC_NOTIFICATION_TIMEPERIOD:
 	case CMD_CHANGE_HOST_MODATTR:
 	case CMD_CHANGE_SVC_MODATTR:
+	case CMD_DEL_DOWNTIME_BY_HOST_NAME:
 		/*
 		 * looks like we have everything we need, so get the
 		 * selection based on the hostname so the daemon knows

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -36,6 +36,12 @@ post:
     ulimit -c unlimited
     mkdir -p /mnt/logs
     echo "core ulimit: \$(ulimit -c)"
+
+    # Workaround for EL7.7 bug BZ#1731062 (https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.7_release_notes/known_issues)
+    if [ -f /usr/bin/systemctl ]; then
+      ln -s /usr/bin/resolveip /usr/libexec/resolveip
+    fi
+
     # skip systemd tests on EL6
     if [ -f /usr/bin/systemctl ]; then
       cucumber --strict --format html --out /mnt/logs/cucumber.html --format pretty


### PR DESCRIPTION
Prior to this commit the external command DEL_DOWNTIME_BY_HOST_NAME was
send to all nodes. However we should not send this command to a poller,
if that poller isn't handling the host.

This is part of MON-9109

Signed-off-by: Jacob Hansen <jhansen@op5.com>