### PR TITLE
Fix segmentation fault on long log messages

### DIFF
--- a/shared/logging.c
+++ b/shared/logging.c
@@ -142,6 +142,10 @@ void log_msg(int severity, const char *fmt, ...)
 	if (len < 0)
 		return;
 
+	/* Set to max size length if it was truncated */
+	if (len > 4095)
+		len=4095;
+
 	if (msg[len] == '\n')
 		msg[len] = 0;
 


### PR DESCRIPTION
In some very rare cases, very long log message might be passed to the log function. If the resulting log message is longer than 4096, we would segfault when accessing `msg[len]`, because the return value of `vsnprintf` is "he number of characters that would have been written if n had been sufficiently large"

To fix this, we set the len to 4095, in case the the message is too long.

This fixes MON-12041