### PR TITLE
Logrotate: Restart merlind first, then Naemon (7.5)

### DIFF
--- a/data/merlin.in
+++ b/data/merlin.in
@@ -6,8 +6,8 @@
 	missingok
 	postrotate
 		if command -v systemctl &>/dev/null; then
-			systemctl try-restart naemon > /dev/null 2>&1
 			systemctl try-restart merlind > /dev/null 2>&1
+			systemctl try-restart naemon > /dev/null 2>&1
 		else
 			service naemon status
 			mon_running=$?


### PR DESCRIPTION
When doing a restart of Naemon and Merlin, we always restart the Merlin
daemon first, follow by restarting Naemon. However the logrotation script
of EL7, does it the opposite way around.

This commit changes the logrotation script to restart in the right
order.

This might fix: MON-11910

Signed-off-by: Jacob Hansen <jhansen@op5.com>