### PR TITLE
Use systemctl instead of service

### DIFF
--- a/apps/libexec/restart.sh.in
+++ b/apps/libexec/restart.sh.in
@@ -10,5 +10,6 @@ mon oconf poller-fix
 # However for some reason the service restart command does not exists until
 # we have called service stop of either merlin or naemon. Therefore we first
 # restart merlin with seperate commands, and thereafter restart naemon.
-/sbin/service merlind stop && /sbin/service merlind start
-/sbin/service naemon restart
+/bin/systemctl stop merlind && /bin/systemctl start merlind
+/bin/systemctl restart naemon
+/bin/systemctl start op5-monitor

--- a/apps/libexec/start.sh
+++ b/apps/libexec/start.sh
@@ -3,5 +3,6 @@
 # Fix object config (does nothing if we're not a poller)
 mon oconf poller-fix
 
-/sbin/service merlind start
-/sbin/service naemon start
+/bin/systemctl start merlind
+/bin/systemctl start naemon
+/bin/systemctl start op5-monitor

--- a/apps/libexec/stop.sh
+++ b/apps/libexec/stop.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-/sbin/service naemon stop
-/sbin/service merlind stop
+/bin/systemctl stop naemon
+/bin/systemctl stop merlind


### PR DESCRIPTION
Since we no longer support EL6, we can migrate to use systemctl without
any issues.

Also added a start command to the op5-monitor service in order to fix
MON-11559.

Signed-off-by: Jacob Hansen <jhansen@op5.com>