### PR TITLE
Apps: fix exception in mon check distribution

### DIFF
--- a/apps/libexec/check.py
+++ b/apps/libexec/check.py
@@ -80,10 +80,10 @@ def cmd_distribution(args):
 			print_perfdata = False
 
 	expired = get_expired(qh)
-	if list(expired)[0] == -1:
+	if expired and expired[0] == -1:
 		return 1
 	info = get_merlin_nodeinfo(qh)
-	
+
 	state = 3
 	if not expired:
 		print "OK: All %i nodes run their assigned checks" % (len(info),),


### PR DESCRIPTION
This fixes a regression that occurred due to the fix of MON-10954.

If there are no expired checks, the list of expired checks is empty,
hence the 0th index could not be checked. This commit puts a safeguard
around the check.

This fixes: MON-12097