### PR TITLE
Apps: Conditional start of op5-monitor service

### DIFF
--- a/apps/libexec/restart.sh.in
+++ b/apps/libexec/restart.sh.in
@@ -12,4 +12,6 @@ mon oconf poller-fix
 # restart merlin with seperate commands, and thereafter restart naemon.
 /bin/systemctl stop merlind && /bin/systemctl start merlind
 /bin/systemctl restart naemon
-/bin/systemctl start op5-monitor
+if systemctl list-units --full -all | grep -Fq "op5-monitor.service"; then
+    /bin/systemctl start op5-monitor
+fi

--- a/apps/libexec/start.sh
+++ b/apps/libexec/start.sh
@@ -5,4 +5,6 @@ mon oconf poller-fix
 
 /bin/systemctl start merlind
 /bin/systemctl start naemon
-/bin/systemctl start op5-monitor
+if systemctl list-units --full -all | grep -Fq "op5-monitor.service"; then
+    /bin/systemctl start op5-monitor
+fi


### PR DESCRIPTION
In the current CI system, many components rely on the `mon restart` and
`mon start` commands. However the CI system, just install the required
packages (as defined by the rpm dependencies). This results in the
op5-monitor service being missing in quite a few CI tests, causing the
start/restart scripts to fail.

This commit therefore first checks if the op5-monitor service exists on
the system, before attempting to start it.