### PR TITLE
Implement public key encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ sltest
 test-lparse
 import
 showlog
+keygen
 *.pyc
 oconf
 test-dbwrap

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 bin_PROGRAMS = merlind
 
 merlinlibdir = $(pkglibdir)
-merlinlib_PROGRAMS = import showlog rename oconf
+merlinlib_PROGRAMS = import showlog rename oconf keygen
 merlinlib_SCRIPTS = install-merlin.sh
 bin_SCRIPTS = apps/op5
 
@@ -16,6 +16,7 @@ mon_SCRIPTS = \
 	apps/libexec/db.py \
 	apps/libexec/ecmd.py \
 	apps/libexec/log.py \
+	apps/libexec/merlinkey.py \
 	apps/libexec/node.py \
 	apps/libexec/node.tree.php \
 	apps/libexec/oconf.fetch.sh \
@@ -104,6 +105,7 @@ common_sources = \
 shared_sources = $(common_sources) \
 	shared/ipc.c shared/ipc.h \
 	shared/io.c shared/io.h \
+	shared/encryption.c shared/encryption.h \
 	shared/node.c shared/node.h \
 	shared/codec.c shared/codec.h \
 	shared/binlog.c shared/binlog.h \
@@ -158,6 +160,10 @@ rename_SOURCES = $(app_sources) tools/rename.c $(db_wrap_sources)
 rename_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/daemon $(GLIB_CFLAGS)
 rename_LDADD = $(naemon_LIBS) $(AM_LDADD) $(GLIB_LIBS)
 
+keygen_SOURCES = tools/keygen.c
+keygen_CFLAGS = $(AM_CFLAGS)
+keygen_LDADD = -lsodium
+
 check_PROGRAMS = $(TESTS) test-dbwrap merlincat cukemerlin
 TESTS = sltest test-csync test-lparse hooktest stringutilstest showlogtest bltest codectest importlogtest
 TESTS_ENVIRONMENT = G_DEBUG=fatal-criticals; export G_DEBUG;
@@ -171,7 +177,7 @@ test_lparse_SOURCES = tests/test-lparse.c tools/lparse.c tools/logutils.c tools/
 test_lparse_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/tools $(GLIB_CFLAGS)
 test_lparse_CPPFLAGS = $(AM_CPPFLAGS)
 test_lparse_LDADD = $(naemon_LIBS)
-hooktest_SOURCES = tests/test-hooks.c module/net.c module/testif_qh.c module/script-helpers.c shared/cfgfile.c shared/shared.c shared/logging.c shared/dlist.c shared/io.c shared/node.c shared/codec.c shared/binlog.c module/misc.c module/sha1.c tools/test_utils.c module/oconfsplit.c shared/configuration.c module/queries.c
+hooktest_SOURCES = tests/test-hooks.c module/net.c module/testif_qh.c module/script-helpers.c shared/cfgfile.c shared/shared.c shared/logging.c shared/dlist.c shared/io.c shared/encryption.c shared/node.c shared/codec.c shared/binlog.c module/misc.c module/sha1.c tools/test_utils.c module/oconfsplit.c shared/configuration.c module/queries.c
 hooktest_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/module -I$(srcdir)/tools $(check_CFLAGS) $(GLIB_CFLAGS)
 hooktest_LDADD = $(naemon_LIBS) $(check_LIBS)
 stringutilstest_SOURCES = tests/test-stringutils.c tools/test_utils.c daemon/string_utils.c
@@ -211,7 +217,7 @@ endif
 	$(mkinstalldirs) -o $(naemon_user):$(naemon_group) $(DESTDIR)$(cachedir)
 	$(mkinstalldirs) -o $(naemon_user):$(naemon_group) $(DESTDIR)$(cachedir)/config
 
-data/merlin data/merlin.cfg data/merlin.conf data/kad.conf sudo/merlin apps/libexec/syscheck/proc_merlind.sh apps/libexec/oconf.fetch.sh apps/libexec/oconf.py apps/mon.py apps/libexec/restart.sh: % : %.in
+data/merlin data/merlin.cfg data/merlin.conf data/kad.conf sudo/merlin apps/libexec/syscheck/proc_merlind.sh apps/libexec/oconf.fetch.sh apps/libexec/oconf.py apps/mon.py apps/libexec/restart.sh apps/libexec/merlinkey.py: % : %.in
 	$(AM_V_GEN) sed \
 		-e 's,@PYTHON[@],$(PYTHON),g' \
 		-e 's,@pkgconfdir[@],$(pkgconfdir),g' \

--- a/apps/libexec/.gitignore
+++ b/apps/libexec/.gitignore
@@ -1,2 +1,3 @@
 oconf.py
 oconf.fetch.sh
+merlinkey.py

--- a/apps/libexec/merlinkey.py.in
+++ b/apps/libexec/merlinkey.py.in
@@ -1,0 +1,33 @@
+import os, sys
+import time
+import subprocess as sp
+
+merlin_conf_dir = "@pkgconfdir@"
+
+def cmd_generate(args):
+	""" --path=</path/to/save/keys>
+	Generates secure keys for encrypting Merlin communication
+
+	By default the keys are placed in /@pkgconfdir@.
+	"""
+
+	path = merlin_conf_dir
+	for arg in args:
+		if arg.startswith('--path'):
+			path = arg.split('=', 1)[1]
+
+	if os.path.isfile(path + '/key.pub'):
+		print 'File already exists. Key will not be generated.'
+		sys.exit(1)
+
+	if os.path.isfile(path + '/key.priv'):
+		print 'File already exists. Key will not be generated.'
+		sys.exit(1)
+
+	p = sp.Popen(['/usr/lib64/merlin/keygen', "-p", path], stdout=sp.PIPE, stderr=sp.PIPE)
+	p.wait()
+	if p.returncode != 0:
+		print 'Key generation failed'
+		sys.exit(1)
+	else:
+		print 'Key generated and saved at ' + path

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AX_CHECK_COMPILE_FLAG([-Wstrict-prototypes], AM_CFLAGS+=" -Wstrict-prototypes")
 AX_CHECK_COMPILE_FLAG([-Wno-unused-parameter], AM_CFLAGS+=" -Wno-unused-parameter")
 AX_CHECK_COMPILE_FLAG([-Wno-strict-aliasing], AM_CFLAGS+=" -Wno-strict-aliasing")
 AX_CHECK_COMPILE_FLAG([-Wno-error=unused-result], AM_CFLAGS+=" -Wno-error=unused-result")
+AX_CHECK_COMPILE_FLAG([-lsodium], AM_CFLAGS+=" -lsodium")
 
 AC_SUBST([AM_CPPFLAGS])
 AC_SUBST([AM_CFLAGS])

--- a/merlin.spec
+++ b/merlin.spec
@@ -41,6 +41,8 @@ Requires: glib2
 Requires: nrpe
 Requires: libdbi
 Requires: libdbi-dbd-mysql
+Requires: libsodium
+BuildRequires: libsodium-devel
 %if 0%{?rhel} >= 7
 BuildRequires: systemd
 BuildRequires: mariadb-devel
@@ -355,6 +357,7 @@ service_control_function restart nrpe || :
 %_libdir/merlin/showlog
 %_libdir/merlin/rename
 %_libdir/merlin/oconf
+%_libdir/merlin/keygen
 %mod_path/import
 %mod_path/showlog
 %mod_path/rename

--- a/shared/encryption.c
+++ b/shared/encryption.c
@@ -1,0 +1,78 @@
+#include "shared.h"
+#include "configuration.h"
+#include "logging.h"
+#include "ipc.h"
+#include "node.h"
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sodium.h>
+#include <stdbool.h>
+
+bool sodium_init_done = false;
+int init_sodium(void);
+
+int open_encryption_key(char * path, unsigned char * target, size_t size){
+	FILE *f;
+	size_t read;
+
+	f = fopen(path, "r");
+	if (f == NULL) {
+		lerr("Failed to open encryption file for writing");
+		return -1;
+	}
+
+	read = fread(target, size, 1, f);
+	if (read != 1) {
+		lerr("Could not read encryption key");
+		return -1;
+	}
+
+	if (fclose(f) != 0) {
+		lerr("Failed open encryption file stream");
+		return -1;
+	}
+	return 0;
+}
+
+int init_sodium() {
+	if (sodium_init_done == false) {
+		if (sodium_init() < 0) {
+			lwarn("sodium_init failed\n");
+			return -1;
+		} else {
+			sodium_init_done = true;
+		}
+	}
+	return 0;
+}
+
+int encrypt_pkt(merlin_event * pkt, merlin_node * recv) {
+
+	if (init_sodium() == -1) {
+		return -1;
+	}
+
+	randombytes_buf(pkt->hdr.nonce, sizeof(pkt->hdr.nonce));
+
+	if (crypto_box_detached((unsigned char *)pkt->body, pkt->hdr.authtag, (unsigned char *)pkt->body, pkt->hdr.len, pkt->hdr.nonce, recv->pubkey, ipc.privkey) != 0) {
+		lerr("could not encrypt msg!\n");
+		return -1;
+	}
+	return 0;
+}
+
+int decrypt_pkt(merlin_event * pkt, merlin_node * sender) {
+	if (init_sodium() == -1) {
+		return -1;
+	}
+
+	if (crypto_box_open_detached((unsigned char *)pkt->body, (const unsigned char *)pkt->body, pkt->hdr.authtag, pkt->hdr.len, pkt->hdr.nonce, sender->pubkey, ipc.privkey) != 0) {
+			lerr("Encrypted message forged!\n");
+			return -1;
+	}
+
+	return 0;
+}
+
+

--- a/shared/encryption.h
+++ b/shared/encryption.h
@@ -1,0 +1,10 @@
+#ifndef INCLUDE_encryption_h__
+#define INCLUDE_encryption_h__
+
+#include "shared.h"
+
+int encrypt_pkt(merlin_event * pkt, merlin_node * sender);
+int decrypt_pkt(merlin_event * pkt, merlin_node * recv);
+int open_encryption_key(char * path, unsigned char * target, size_t size);
+
+#endif

--- a/shared/ipc.c
+++ b/shared/ipc.c
@@ -7,6 +7,7 @@
 #include "ipc.h"
 #include "io.h"
 #include "node.h"
+#include "encryption.h"
 
 static int listen_sock = -1; /* for bind() and such */
 static char *ipc_sock_path;
@@ -182,6 +183,15 @@ static int ipc_set_sock_path(const char *path)
 	return 0;
 }
 
+static int ipc_set_private_key(const char * path) {
+	if ( open_encryption_key(path, ipc.privkey,
+				crypto_box_SECRETKEYBYTES) ) {
+		lerr("Could not open ipc_privatekey: %s\n", path);
+		return 1;
+	}
+	return 0;
+}
+
 int ipc_grok_var(char *var, char *val)
 {
 	if (!val)
@@ -189,6 +199,10 @@ int ipc_grok_var(char *var, char *val)
 
 	if (!strcmp(var, "ipc_socket"))
 		return !ipc_set_sock_path(val);
+
+	if (!strcmp(var, "ipc_privatekey")) {
+		return !ipc_set_private_key(val);
+	}
 
 	if (!strcmp(var, "ipc_binlog")) {
 		lwarn("%s is deprecated. The name will always be computed.", var);

--- a/tests/test-hooks.c
+++ b/tests/test-hooks.c
@@ -124,7 +124,7 @@ static void expiration_teardown(void)
 
 START_TEST(set_clear_svc_expire)
 {
-	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0}},{0}};
+	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0},"", ""},{0}};
 	nebstruct_service_check_data ds = {0,};
 	ds.type = NEBTYPE_SERVICECHECK_ASYNC_PRECHECK;
 	ds.object_ptr = host_ary[0]->services->service_ptr;
@@ -154,7 +154,7 @@ END_TEST
 
 START_TEST(set_clear_host_expire)
 {
-	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0}},{0}};
+	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0},"", ""},{0}};
 	nebstruct_host_check_data ds = {0,};
 	ds.type = NEBTYPE_HOSTCHECK_ASYNC_PRECHECK;
 	ds.object_ptr = host_ary[0];
@@ -185,7 +185,7 @@ END_TEST
 START_TEST(multiple_svc_expire)
 {
 	void *first_user_data;
-	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0}},{0}};
+	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0},"", ""},{0}};
 	nebstruct_service_check_data ds0 = {0,}, ds1 = {0,};
 	ds0.type = NEBTYPE_SERVICECHECK_ASYNC_PRECHECK;
 	ds0.object_ptr = host_ary[0]->services->service_ptr;
@@ -227,7 +227,7 @@ END_TEST
 START_TEST(multiple_host_expire)
 {
 	void *first_user_data;
-	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0}},{0}};
+	merlin_event pkt = {{{0,},0,0,0,0,0,{0,},{0},"", ""},{0}};
 	nebstruct_host_check_data ds0 = {0,}, ds1 = {0,};
 	ds0.type = NEBTYPE_HOSTCHECK_ASYNC_PRECHECK;
 	ds0.object_ptr = host_ary[0];

--- a/tools/keygen.c
+++ b/tools/keygen.c
@@ -1,0 +1,98 @@
+#include <getopt.h>
+#include <sodium.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int write_key(char *path, unsigned char *key, size_t len) {
+  FILE *f;
+  size_t written;
+
+  f = fopen(path, "w");
+
+  if (f == NULL) {
+    printf("Failed to open file for writing: %s\n", path);
+    return 1;
+  }
+
+  written = fwrite(key, len, 1, f);
+  if (written != 1) {
+    printf("Failed writing to file: %s\n", path);
+    printf("Written: %ld\n", written);
+    return 1;
+  }
+  if (fclose(f) != 0) {
+    printf("Failed to close file stream: %s\n", path);
+    return 1;
+  }
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  unsigned char pubkey[crypto_box_PUBLICKEYBYTES];
+  unsigned char privkey[crypto_box_SECRETKEYBYTES];
+  char *path = NULL;
+  char *pubkey_path = NULL;
+  char *privkey_path = NULL;
+  char pubkey_file[] = "/key.pub";
+  char privkey_file[] = "/key.priv";
+
+  int c;
+
+  while ((c = getopt(argc, argv, "p:")) != -1)
+    switch (c) {
+    case 'p':
+      path = optarg;
+      break;
+    case '?':
+      if (optopt == 'p')
+        fprintf(stderr, "Option -%c requires an argument.\n", optopt);
+      else if (isprint(optopt))
+        fprintf(stderr, "Unknown option `-%c'.\n", optopt);
+      else
+        fprintf(stderr, "Unknown option character `\\x%x'.\n", optopt);
+      return 1;
+    default:
+      return 1;
+    }
+
+  if (path == NULL) {
+    fprintf(stderr, "A path must be supplied with the -p argument\n");
+    return 1;
+  }
+
+  if (sodium_init() < 0) {
+    printf("%s\n", "Could init crypo lib. Exiting.");
+    return 1;
+  }
+
+  crypto_box_keypair(pubkey, privkey);
+
+  // size of path prefix plus length of filename plus one for string terminator
+  pubkey_path = malloc(sizeof(char) * (strlen(path) + strlen(pubkey_file) + 1));
+  privkey_path =
+      malloc(sizeof(char) * (strlen(path) + strlen(privkey_file) + 1));
+
+  strcat(pubkey_path, path);
+  strcat(pubkey_path, pubkey_file);
+  strcat(privkey_path, path);
+  strcat(privkey_path, privkey_file);
+
+  if (write_key(pubkey_path, pubkey, crypto_box_PUBLICKEYBYTES)) {
+    free(pubkey_path);
+    free(privkey_path);
+    return 1;
+  }
+
+  if (write_key(privkey_path, privkey, crypto_box_SECRETKEYBYTES)) {
+    free(pubkey_path);
+    free(privkey_path);
+    return 1;
+  }
+
+  free(pubkey_path);
+  free(privkey_path);
+
+  return 0;
+}


### PR DESCRIPTION
This commit implements encyrption of Merlin communication on port 15551.
The implementation is done using libsodium and the encryption cipher
used is XSalsa20.

The encryption is done on the body of the merlin packet, the header
remains unencrypted.

With this commit the merlin packet header is increased, to accomendate
sending the nonce in the header. Due to this the
`MERLIN_PROTOCOL_VERSION` is increased.

This fixes MON-12110