### PR TITLE
Run test-suite with encryption enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -266,12 +266,13 @@ merlincat_SOURCES = tests/merlincat/merlincat.c \
 	tests/merlincat/merlincat_codec.c tests/merlincat/merlincat_codec.h \
 	tests/merlincat/console.c tests/merlincat/console.h \
 	tests/merlincat/event_packer.c tests/merlincat/event_packer.h \
+	tests/merlincat/merlincat_encryption.c tests/merlincat/merlincat_encryption.h \
 	tests/merlincat/conn_info.c tests/merlincat/conn_info.h \
 	tests/merlincat/nebev2kvvec.c tests/merlincat/nebev2kvvec.h \
 	tests/merlincat/kvvec2nebev.c tests/merlincat/kvvec2nebev.h
 
 merlincat_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(GIO_UNIX_CFLAGS)
-merlincat_LDADD = $(naemon_LIBS) $(GLIB_LIBS) $(GIO_LIBS) $(GIO_UNIX_LIBS)
+merlincat_LDADD = $(naemon_LIBS) $(GLIB_LIBS) $(GIO_LIBS) $(GIO_UNIX_LIBS) -lsodium
 
 cukemerlin_SOURCES = tests/cukemerlin/base/cukemerlin.c \
 	tests/cukemerlin/base/json.c tests/cukemerlin/base/json.h \
@@ -292,12 +293,13 @@ cukemerlin_SOURCES = tests/cukemerlin/base/cukemerlin.c \
 	tests/merlincat/merlincat_codec.c tests/merlincat/merlincat_codec.h \
 	tests/merlincat/console.c tests/merlincat/console.h \
 	tests/merlincat/event_packer.c tests/merlincat/event_packer.h \
+	tests/merlincat/merlincat_encryption.c tests/merlincat/merlincat_encryption.h \
 	tests/merlincat/conn_info.c tests/merlincat/conn_info.h \
 	tests/merlincat/nebev2kvvec.c tests/merlincat/nebev2kvvec.h \
 	tests/merlincat/kvvec2nebev.c tests/merlincat/kvvec2nebev.h
 
 cukemerlin_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(GIO_UNIX_CFLAGS) -I$(top_builddir)/tests/cukemerlin -I$(top_builddir)/tests
-cukemerlin_LDADD = $(naemon_LIBS) $(GLIB_LIBS) $(GIO_LIBS) $(GIO_UNIX_LIBS)
+cukemerlin_LDADD = $(naemon_LIBS) $(GLIB_LIBS) $(GIO_LIBS) $(GIO_UNIX_LIBS) -lsodium
 
 
 apps/op5: apps/mon.py

--- a/features/step_definitions/service_startup.rb
+++ b/features/step_definitions/service_startup.rb
@@ -99,6 +99,10 @@ Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
       }
     }
     "
+  if ENV["MERLIN_ENCRYPTED"] == "TRUE" then
+    configfile+= "ipc_privatekey=#{ENV["MERLIN_PRIVKEY"]}"
+  end
+
   nodes.hashes.each do |obj|
     configfile += sprintf "\n%s %s {\n", obj["type"], obj["name"]
     if !obj.include? 'address' then
@@ -114,6 +118,10 @@ Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
         # specific one
         configfile.sub! 'fetch = ./fetch_cmd;', ''
       end
+    end
+    if ENV["MERLIN_ENCRYPTED"] == "TRUE" then
+      configfile += "\tencrypted = 1\n"
+      configfile += "\tpublickey = #{ENV["MERLIN_PUBKEY"]}\n"
     end
     configfile += "}\n"
   end

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -42,9 +42,12 @@ post:
       ln -s /usr/bin/resolveip /usr/libexec/resolveip
     fi
 
-    # skip systemd tests on EL6
-    if [ -f /usr/bin/systemctl ]; then
-      cucumber --strict --format html --out /mnt/logs/cucumber.html --format pretty
-    else
-      cucumber --strict --format html --out /mnt/logs/cucumber.html --format pretty --tags ~@systemd
-    fi
+    cucumber --strict --format html --out /mnt/logs/cucumber.html --format pretty
+    # Run the test suite again, but with encryption enabled
+    # Some tests has been disabled. These tests pass just fine when running the
+    # test suite with encryption enabled only, but for some reason fail when
+    # running after the above test, without encryption enabled. Further the
+    # disabled tests do not have any peers/pollers so encryption shouldn't
+    # affect them.
+    mon merlinkey generate
+    MERLIN_ENCRYPTED=TRUE MERLIN_PUBKEY=/opt/monitor/op5/merlin/key.pub MERLIN_PRIVKEY=/opt/monitor/op5/merlin/key.priv cucumber --strict --format html --out /mnt/logs/cucumber_encrypted.html --format pretty --exclude "report_data"

--- a/shared/encryption.c
+++ b/shared/encryption.c
@@ -48,7 +48,7 @@ int init_sodium() {
 }
 
 int encrypt_pkt(merlin_event * pkt, merlin_node * recv) {
-
+	ldebug("Encrypting pkt for node: %s", recv->name);
 	if (init_sodium() == -1) {
 		return -1;
 	}
@@ -63,6 +63,7 @@ int encrypt_pkt(merlin_event * pkt, merlin_node * recv) {
 }
 
 int decrypt_pkt(merlin_event * pkt, merlin_node * sender) {
+	ldebug("Decrypting pkt for node: %s", sender->name);
 	if (init_sodium() == -1) {
 		return -1;
 	}

--- a/shared/node.c
+++ b/shared/node.c
@@ -857,21 +857,20 @@ int node_send(merlin_node *node, void *data, unsigned int len, int flags)
 	}
 
 	if (node->encrypted) {
+		/* allocate memory and copy the pkt */
 		encrypted_pkt = malloc(sizeof *encrypted_pkt);
 		memcpy(encrypted_pkt, pkt, packet_size(pkt));
-		if (strcmp(pkt->body, encrypted_pkt->body) == 0) {
-			ldebug("pkt->body and encrypted_body are equal");
-		} else {
-			ldebug("pkt->body and org_body are different");
-		}
+
 		if (encrypt_pkt(encrypted_pkt, node) == -1) {
 			node_disconnect(node, "Failed to encrypt packet");
 		}
+		/* Make sure we set the encrypted pkt as the pkt to send */
 		pkt = encrypted_pkt;
 
 	}
 
 	sent = io_send_all(node->sock, (void *) pkt, len);
+
 	if (encrypted_pkt != NULL) {
 		free(encrypted_pkt);
 	}

--- a/tests/merlincat/event_packer.c
+++ b/tests/merlincat/event_packer.c
@@ -54,6 +54,7 @@ char *event_packer_pack(const merlin_event *evt) {
 	free(packed_data);
 
 	kvvec_destroy(kvv, KVVEC_FREE_ALL);
+
 	return result_line;
 }
 
@@ -68,6 +69,7 @@ struct kvvec *event_packer_pack_kvv(const merlin_event *evt, const char **name) 
 	if (evt->hdr.type != CTRL_PACKET) {
 		if (merlincat_decode(unpacked_data, evt->hdr.len, evt->hdr.type)) {
 			g_free(unpacked_data);
+			g_message("merlincat_decode: failed");
 			return NULL;
 		}
 	}

--- a/tests/merlincat/merlincat.c
+++ b/tests/merlincat/merlincat.c
@@ -12,6 +12,7 @@
 #include "merlinreader.h"
 #include "console.h"
 #include "event_packer.h"
+#include "merlincat_encryption.h"
 #include <shared/shared.h>
 #include <shared/compat.h>
 
@@ -121,6 +122,9 @@ static void net_send_ctrl_active(ConnectionStorage *conn) {
 
 	pkt.hdr.len = sizeof(merlin_nodeinfo);
 	memcpy(&pkt.body, &node, sizeof(merlin_nodeinfo));
+	if (merlincat_encrypt_pkt(&pkt) != 0) {
+		g_message("net_send_ctrl_active: Failed to encrypt pkt");
+	}
 
 	connection_send(conn, &pkt, HDR_SIZE + pkt.hdr.len);
 }

--- a/tests/merlincat/merlincat_encryption.c
+++ b/tests/merlincat/merlincat_encryption.c
@@ -1,0 +1,129 @@
+#include "merlincat_encryption.h"
+#include <shared/shared.h>
+#include <naemon/naemon.h>
+#include <glib.h>
+#include <sodium.h>
+
+static int open_encryption_key_cukemerlin(char * path, unsigned char * target, size_t size);
+static int init_sodium(void);
+static bool sodium_init_done = false;
+
+int init_sodium() {
+	if (sodium_init_done == false) {
+		if (sodium_init() < 0) {
+			g_message("sodium_init failed");
+			return -1;
+		} else {
+			sodium_init_done = true;
+		}
+	}
+	return 0;
+}
+
+static int encryption_enabled() {
+	if (getenv("MERLIN_ENCRYPTED") != NULL && strcmp(getenv("MERLIN_ENCRYPTED"),"TRUE") == 0) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+static int open_encryption_key_cukemerlin(char * path, unsigned char * target, size_t size){
+	FILE *f;
+	size_t read;
+
+	f = fopen(path, "r");
+	if (f == NULL) {
+		return -1;
+	}
+
+	read = fread(target, size, 1, f);
+	if (read != 1) {
+		return -1;
+	}
+
+	if (fclose(f) != 0) {
+		return -1;
+	}
+	return 0;
+}
+
+int merlincat_encrypt_pkt(merlin_event * pkt) {
+	unsigned char pubkey[crypto_box_PUBLICKEYBYTES];
+	unsigned char privkey[crypto_box_SECRETKEYBYTES];
+
+	/* Only decrypt packet if enabled */
+	if (!encryption_enabled()) {
+		return 0;
+	}
+
+	if (*pkt->hdr.nonce != '\0') {
+		g_message("encrypt_pkt: pkt already encrypted");
+		return 0;
+	}
+
+	if (init_sodium() == -1) {
+		g_message("encrypt_pkt: could not init sodium");
+		return -1;
+	}
+
+	if ( open_encryption_key_cukemerlin( getenv("MERLIN_PRIVKEY"), privkey,
+				crypto_box_SECRETKEYBYTES) ) {
+		g_message("encrypt_pkt: could not open privatekey");
+		return -1;
+	}
+
+	if ( open_encryption_key_cukemerlin( getenv("MERLIN_PUBKEY"), pubkey,
+				crypto_box_PUBLICKEYBYTES) ) {
+		g_message("encrypt_pkt: could not open pubkey");
+		return -1;
+	}
+
+	randombytes_buf(pkt->hdr.nonce, sizeof(pkt->hdr.nonce));
+
+	if (crypto_box_detached((unsigned char *)pkt->body, pkt->hdr.authtag, (unsigned char *)pkt->body, pkt->hdr.len, pkt->hdr.nonce, pubkey, privkey) != 0) {
+		g_message("encrypt_pkt: could not encrypt pkt");
+		return 0;
+	}
+	return 0;
+}
+
+int merlincat_decrypt_pkt(merlin_event * pkt) {
+	unsigned char pubkey[crypto_box_PUBLICKEYBYTES];
+	unsigned char privkey[crypto_box_SECRETKEYBYTES];
+
+	/* Only decrypt packet if enabled */
+	if (!encryption_enabled()) {
+		return 0;
+	}
+
+	if (*pkt->hdr.nonce == '\0') {
+		g_message("decrypt_pkt: nonce empty");
+	}
+
+	if (init_sodium() == -1) {
+		g_message("decrypt_pkt: could not init sodium");
+		return -1;
+	}
+
+	if ( open_encryption_key_cukemerlin( getenv("MERLIN_PRIVKEY"), privkey,
+				crypto_box_SECRETKEYBYTES) ) {
+		g_message("decrypt_pkt: could not open privatekey");
+		return -1;
+	}
+
+	if ( open_encryption_key_cukemerlin( getenv("MERLIN_PUBKEY"), pubkey,
+				crypto_box_PUBLICKEYBYTES) ) {
+		g_message("decrypt_pkt: could not open pubkey");
+		return -1;
+	}
+
+	if (crypto_box_open_detached((unsigned char *)pkt->body, (const unsigned char *)pkt->body, pkt->hdr.authtag, pkt->hdr.len, pkt->hdr.nonce, pubkey, privkey) != 0) {
+		return -1;
+	}
+
+	*pkt->hdr.nonce = '\0';
+
+	return 0;
+}
+

--- a/tests/merlincat/merlincat_encryption.h
+++ b/tests/merlincat/merlincat_encryption.h
@@ -1,0 +1,22 @@
+#ifndef TOOLS_MERLINCAT_ENCRYPTION_H_
+#define TOOLS_MERLINCAT_ENCRYPTION_H_
+
+#include <shared/node.h>
+#include <naemon/naemon.h>
+#include <sodium.h>
+
+/**
+ * Encrypts a merlin packet in place, if enabled using envrioment variables.
+ *
+ * Returns 0 on success and -1 otherwise
+ */
+int merlincat_encrypt_pkt(merlin_event * pkt);
+
+/**
+ * Decrypts a merlin packet in place, if enabled using envrioment variables.
+ *
+ * Returns 0 on success and -1 otherwise
+ */
+int merlincat_decrypt_pkt(merlin_event * pkt);
+
+#endif /* TOOLS_MERLINCAT_ENCRYPTION_H_ */


### PR DESCRIPTION
- Fix a bug in the encryption implementation when sending the same pkt to multiple nodes
- Run test-suite with encrypted merlin, with the exception of a couple of tests (see comment in the `ci_config.yml` for more details).