### PR TITLE
Apps: Show encryption status in mon node status

### DIFF
--- a/apps/libexec/node.py
+++ b/apps/libexec/node.py
@@ -90,6 +90,7 @@ def cmd_status(args):
 		iid = int(info.get('instance_id', 0))
 		node = mconf.configured_nodes.get(info['name'], False)
 		is_running = info.get('state') == 'STATE_CONNECTED'
+		is_encrypted = info.get("encrypted") == '1'
 		if is_running:
 			# latency is in milliseconds, so convert to float
 			latency = float(info.get('latency')) / 1000.0
@@ -126,6 +127,12 @@ def cmd_status(args):
 
 		if is_running:
 			name += ": %sACTIVE%s - %s%.3fs%s latency" % (color.green, color.reset, lat_color, latency, color.reset)
+			# Only show encryption status for non-ipc nodes
+			if "ipc" not in info['name']:
+				if is_encrypted:
+					name += " - (%sENCRYPTED%s)" % (color.green, color.reset)
+				else:
+					name += " - (UNENCRYPTED)"
 		else:
 			name += " (%sINACTIVE%s)" % (color.red, color.reset)
 			exit_code = 1

--- a/shared/ipc.c
+++ b/shared/ipc.c
@@ -58,7 +58,8 @@ int dump_nodeinfo(merlin_node *n, int sd, int instance_id)
 				 "csync_num_attempts=%d;csync_max_attempts=%d;"
 				 "csync_last_attempt=%lu;"
 				 "csync_push_cmd=%s;csync_push_is_running=%d;"
-				 "csync_fetch_cmd=%s;csync_fetch_is_running=%d"
+				 "csync_fetch_cmd=%s;csync_fetch_is_running=%d;"
+				 "encrypted=%d"
 				 "\n",
 				 instance_id,
 				 n->name, n->source_name, n->sock, node_type(n),
@@ -91,7 +92,8 @@ int dump_nodeinfo(merlin_node *n, int sd, int instance_id)
 				 n->csync_num_attempts, n->csync_max_attempts,
 				 n->csync_last_attempt,
 				 n->csync.push.cmd ? n->csync.push.cmd : "", n->csync.push.is_running,
-				 n->csync.fetch.cmd ? n->csync.fetch.cmd : "", n->csync.fetch.is_running
+				 n->csync.fetch.cmd ? n->csync.fetch.cmd : "", n->csync.fetch.is_running,
+				 n->encrypted
 				);
 	return 0;
 }


### PR DESCRIPTION
With this commit the encryption status is added to the node info dump.
This in turn allows us to print the encryption status when executing `mon
node status`.

This fixes: MON-12111