### PR TITLE
Pre-calculate shared encryption key

### DIFF
--- a/module/module.c
+++ b/module/module.c
@@ -1638,6 +1638,10 @@ int nebmodule_deinit(__attribute__((unused)) int flags, __attribute__((unused)) 
 		free(node->name);
 		free(node->source_name);
 		free(node->hostgroups);
+		// unlock and zero out shared key for encrypted nodes
+		if (node->encrypted) {
+			sodium_munlock(node->sharedkey, crypto_box_BEFORENMBYTES);
+		}
 	}
 	safe_free(node_table);
 

--- a/shared/encryption.h
+++ b/shared/encryption.h
@@ -5,6 +5,6 @@
 
 int encrypt_pkt(merlin_event * pkt, merlin_node * sender);
 int decrypt_pkt(merlin_event * pkt, merlin_node * recv);
-int open_encryption_key(char * path, unsigned char * target, size_t size);
+int open_encryption_key(const char * path, unsigned char * target, size_t size);
 
 #endif

--- a/shared/node.h
+++ b/shared/node.h
@@ -253,8 +253,8 @@ struct merlin_node {
 	time_t csync_last_attempt;
 	int (*action)(struct merlin_node *, int); /* (daemon) action handler */
 	bool encrypted;
- 	unsigned char pubkey[crypto_box_PUBLICKEYBYTES];
 	unsigned char privkey[crypto_box_SECRETKEYBYTES];
+	unsigned char sharedkey[crypto_box_BEFORENMBYTES];
 };
 
 #define node_table noc_table


### PR DESCRIPTION
For performance improvements, we precalculate the shared encryption key
at configuration time. This reduces the performance penalty for enabling
encryption.

This fixes: MON-12187

Signed-off-by: Jacob Hansen <jhansen@itrsgroup.com>