### PR TITLE
Set permission 400 permissions for encryption keys

### DIFF
--- a/apps/libexec/merlinkey.py.in
+++ b/apps/libexec/merlinkey.py.in
@@ -1,8 +1,13 @@
 import os, sys
 import time
+import pwd
+import grp
 import subprocess as sp
 
 merlin_conf_dir = "@pkgconfdir@"
+
+def initchildproc():
+	os.umask(0377)
 
 def cmd_generate(args):
 	""" --path=</path/to/save/keys>
@@ -24,10 +29,15 @@ def cmd_generate(args):
 		print 'File already exists. Key will not be generated.'
 		sys.exit(1)
 
-	p = sp.Popen(['/usr/lib64/merlin/keygen', "-p", path], stdout=sp.PIPE, stderr=sp.PIPE)
+	p = sp.Popen(['/usr/lib64/merlin/keygen', "-p", path], stdout=sp.PIPE,
+			stderr=sp.PIPE, preexec_fn=initchildproc)
 	p.wait()
 	if p.returncode != 0:
 		print 'Key generation failed'
 		sys.exit(1)
 	else:
+		uid = pwd.getpwnam("monitor").pw_uid
+		gid = grp.getgrnam("apache").gr_gid
+		os.chown(path + "/key.priv", uid, gid)
+		os.chown(path + "/key.pub", uid, gid)
 		print 'Key generated and saved at ' + path


### PR DESCRIPTION
The generated keys should only be readable by the monitor user. No other
users on the system should be able to read the keys.