### PR TITLE
Spec: Install keygen tool for slim packages

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -403,6 +403,7 @@ service_control_function restart nrpe || :
 %defattr(-,root,root)
 %_libdir/merlin/oconf
 %_libdir/merlin/mon
+%_libdir/merlin/keygen
 %_bindir/mon
 %_bindir/op5
 %_sysconfdir/cron.d/*


### PR DESCRIPTION
For the apps-slim package, the keygen tool was missing, causing problems
generating keys on the slim poller.

With this commit we correctly include the keygen tool for the slim
poller, too.

Signed-off-by: Jacob Hansen <jhansen@op5.com>