### PR TITLE
Encryption: Remove left-over debugging message

### DIFF
--- a/shared/encryption.c
+++ b/shared/encryption.c
@@ -62,11 +62,14 @@ int encrypt_pkt(merlin_event * pkt, merlin_node * recv) {
 		lerr("could not encrypt msg!\n");
 		return -1;
 	}
+
+	ldebug("Pkt encryption for node: %s succeeded", recv->name);
+
 	return 0;
 }
 
 int decrypt_pkt(merlin_event * pkt, merlin_node * sender) {
-	ldebug("Decrypting pkt for node: %s", sender->name);
+	ldebug("Decrypting pkt from node: %s", sender->name);
 	if (init_sodium() == -1) {
 		return -1;
 	}
@@ -79,6 +82,8 @@ int decrypt_pkt(merlin_event * pkt, merlin_node * sender) {
 		lerr("Encrypted message forged!\n");
 		return -1;
 	}
+
+	ldebug("Pkt decryption from node: %s succeeded", sender->name);
 
 	return 0;
 }

--- a/shared/node.c
+++ b/shared/node.c
@@ -956,7 +956,6 @@ merlin_event *node_get_event(merlin_node *node)
 	}
 
 	if (node->encrypted) {
-		lwarn("Try to decrypt msg");
 		if (decrypt_pkt(pkt, node) == -1) {
 			node_disconnect(node, "Failed to decrypt package from: %s", node->name);
 		}


### PR DESCRIPTION
There was a left-over debug log message printed on the 'Warn' level when
enabling encryption. There are already good debug level logs in place
for both encryption and decryption, so this can be removed completely.

Also add a debug messages saying encryption/decryption went OK.

Signed-off-by: Jacob Hansen <jhansen@op5.com>