### PR TITLE
Set encryption keys to be owned by root group

### DIFF
--- a/apps/libexec/merlinkey.py.in
+++ b/apps/libexec/merlinkey.py.in
@@ -37,7 +37,7 @@ def cmd_generate(args):
 		sys.exit(1)
 	else:
 		uid = pwd.getpwnam("monitor").pw_uid
-		gid = grp.getgrnam("apache").gr_gid
+		gid = grp.getgrnam("root").gr_gid
 		os.chown(path + "/key.priv", uid, gid)
 		os.chown(path + "/key.pub", uid, gid)
 		print 'Key generated and saved at ' + path


### PR DESCRIPTION
On the slim poller we do not have the apache group. Further there is no
reason for the group to be set as apache instead of root as:

- Apache has no need to access the encryption keys
- The group has no access to the file anyway due to the 700 permissions

Signed-off-by: Jacob Hansen <jhansen@op5.com>