### PR TITLE
Use check_op5_license instead to validate

### DIFF
--- a/apps/libexec/syscheck/license.sh
+++ b/apps/libexec/syscheck/license.sh
@@ -1,19 +1,10 @@
-handler_desc='Verifies that the op5 license file is installed and valid.'
+handler_desc='Verifies that the OP5 license file is installed and valid for more than 14 days.'
 handler_exec()
 {
-  lic_file='/etc/op5license/op5license.xml'
-
-  [ -f "$lic_file" ] || \
-    dieplug '2' "No op5 license has been installed."
-  [ -r "$lic_file" ] || \
-    dieplug '3' "Unable to read op5 license file ($lic_file)."
-
-  PATH="/opt/op5sys/bin:$PATH"
-  depchk op5license-verify
-
-  if op5license-verify "$lic_file" &> /dev/null; then
-    dieplug '0' 'op5 license file valid.'
+  /opt/plugins/check_op5_license -T d -w 14 -c 14 &> /dev/null
+  if [ $? -eq 0 ]; then
+    dieplug '0' 'OP5 license check reports license valid for >14 days.'
   else
-    dieplug '2' 'op5 license file invalid.'
+    dieplug '2' 'OP5 license check reports license invalid, or valid for less than 14 days!'
   fi
 }


### PR DESCRIPTION
This command was previously severely outdated as we no longer use XML
licenses, leading to customer complaints that we are shipping a
defective command. There's probably more things we can do here, and 14
days is arbitrary, but since the plugin this depends on *needs* either
days left or amount of hosts to work, the choice here was either to
check if days left was <0 or <N. I elected to choose an arbitrary number
instead because I can't figure out a valid use case for when you would
want a license with less than 14 days to still be marked as OK. If this
doesn't make sense, we can change it later, but at least "mon sysconf
check license" now works.