### PR TITLE
Don't overwrite log level in merlin.conf

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -277,11 +277,6 @@ sed --follow-symlinks -i \
     -e 's#ipc_socket =.*$#ipc_socket = /var/lib/merlin/ipc.sock;#' \
     %mod_path/merlin.conf
 
-# error/warn logging is useless, change it to info
-sed --follow-symlinks -r -i \
-  's/^([[:space:]]*log_level[[:space:]]*=[[:space:]]*)(error|warn)[[:space:]]*;[[:space:]]*$/\1info;/' \
-  %mod_path/merlin.conf
-
 # chown old cached nodesplit data, so it can be deleted
 chown -R %daemon_user:%daemon_group %_localstatedir/cache/merlin
 


### PR DESCRIPTION
The log level was always overwritten on package updates. This makes it
hard to choose the your preffered loglevel. With this patch, we no
longer force the `info` log level.