### PR TITLE
SSH-less test-this-check

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,6 +125,7 @@ module_sources = $(shared_sources) \
 	module/script-helpers.c module/script-helpers.h \
 	module/oconfsplit.c module/oconfsplit.h \
 	module/net.c module/net.h \
+	module/runcmd.c module/runcmd.h \
 	shared/pgroup.c shared/pgroup.h \
 	module/testif_qh.c module/testif_qh.h
 daemon_sources = $(shared_sources) $(db_wrap_sources) \
@@ -176,7 +177,7 @@ test_lparse_SOURCES = tests/test-lparse.c tools/lparse.c tools/logutils.c tools/
 test_lparse_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/tools $(GLIB_CFLAGS)
 test_lparse_CPPFLAGS = $(AM_CPPFLAGS)
 test_lparse_LDADD = $(naemon_LIBS)
-hooktest_SOURCES = tests/test-hooks.c module/net.c module/testif_qh.c module/script-helpers.c shared/cfgfile.c shared/shared.c shared/logging.c shared/dlist.c shared/io.c shared/encryption.c shared/node.c shared/codec.c shared/binlog.c module/misc.c module/sha1.c tools/test_utils.c module/oconfsplit.c shared/configuration.c module/queries.c
+hooktest_SOURCES = tests/test-hooks.c module/net.c module/testif_qh.c module/script-helpers.c shared/cfgfile.c shared/shared.c shared/logging.c shared/dlist.c shared/io.c shared/encryption.c shared/node.c shared/codec.c shared/binlog.c module/misc.c module/sha1.c tools/test_utils.c module/oconfsplit.c shared/configuration.c module/queries.c module/runcmd.c
 hooktest_CFLAGS = $(AM_CFLAGS) -I$(srcdir)/module -I$(srcdir)/tools $(check_CFLAGS) $(GLIB_CFLAGS)
 hooktest_LDADD = $(naemon_LIBS) $(check_LIBS)
 stringutilstest_SOURCES = tests/test-stringutils.c tools/test_utils.c daemon/string_utils.c

--- a/apps/libexec/qh.py
+++ b/apps/libexec/qh.py
@@ -5,9 +5,11 @@ from nagios_qh import nagios_qh
 from merlin_apps_utils import *
 
 qh = '/opt/monitor/var/rw/nagios.qh'
+single = False
 
 def module_init(args):
 	global qh
+	global single
 	rem_args = []
 	comp = cconf.parse_conf(nagios_cfg)
 	for v in comp.params:
@@ -17,6 +19,9 @@ def module_init(args):
 	for arg in args:
 		if arg.startswith('--socket='):
 			qh = arg.split('=', 1)[1]
+			continue
+		if arg == '--single':
+			single = True
 			continue
 		rem_args.append(arg)
 	return rem_args
@@ -34,7 +39,7 @@ def args_to_query(args):
 
 
 def cmd_query(args):
-	"""--socket=</path/to/query-socket> <query>
+	"""--socket=</path/to/query-socket> --single <query>
 	Runs an arbitrary query with the nagios query handler and prints its
 	raw output. Queries need not include the trailing nulbyte or leading
 	hash- or at-sign.
@@ -47,6 +52,8 @@ def cmd_query(args):
 	for block in handler.query(query):
 		print block,
 		sys.stdout.flush()
+		if single:
+			return
 
 def cmd_get(args):
 	"""--socket=</path/to/query-socket> <query>

--- a/features/runcmd.feature
+++ b/features/runcmd.feature
@@ -34,6 +34,6 @@ Feature: Test merlins runcmd feature.
 			| content | command.name=test_command;command.command_line=echo OK;runcmd=test_command |
 		And I wait for 4 second
 
-		Then my_peer received event contains RUNCMD_PACKET
+		Then my_peer received event RUNCMD_PACKET contains
 			| sd      | 29	      |
 			| content | outstd=OK |

--- a/features/runcmd.feature
+++ b/features/runcmd.feature
@@ -1,0 +1,39 @@
+@config @daemons @merlin @queryhandler @livestatus
+Feature: Test merlins runcmd feature.
+
+	Background: Set up naemon configuration
+
+		Given I have naemon hostgroup objects
+			| hostgroup_name | alias |
+			| pollergroup    | PG    |
+			| emptygroup     | EG    |
+		And I have naemon host objects
+			| use          | host_name | address   | contacts  | max_check_attempts | hostgroups  |
+			| default-host | hostA     | 127.0.0.1 | myContact | 2                  | pollergroup |
+			| default-host | hostB     | 127.0.0.2 | myContact | 2                  | pollergroup |
+		And I have naemon service objects
+			| use             | host_name | description |
+			| default-service | hostA     | PONG        |
+			| default-service | hostB     | PONG        |
+		And I have naemon contact objects
+			| use             | contact_name |
+			| default-contact | myContact    |
+
+
+	Scenario: The peer sends a request to "ipc" to execute a RUNCMD command.
+		The peer should recieve a response back.
+
+		Given I start naemon with merlin nodes connected
+			| type   | name        | port |
+			| peer   | my_peer     | 4123 |
+		And I wait for 1 second
+
+		Then my_peer is connected to merlin
+		When my_peer sends event RUNCMD_PACKET
+			| sd      | 29		 							       |
+			| content | command.name=test_command;command.command_line=echo OK;runcmd=test_command |
+		And I wait for 4 second
+
+		Then my_peer received event contains RUNCMD_PACKET
+			| sd      | 29	      |
+			| content | outstd=OK |

--- a/features/step_definitions/service_startup.rb
+++ b/features/step_definitions/service_startup.rb
@@ -35,6 +35,7 @@ Given(/^I start naemon$/) do
       cfg_file=oconf.cfg
       broker_module=#{merlin_module_path} merlin.conf
       broker_module=#{livestatus_module_path} log_file=livestatus.log live
+      broker_module=/usr/lib64/testthis/testthis.so
       include_file=naemon_extra.cfg
       """
     And I have config file checks.log

--- a/features/support/merlin_packet_defaults.rb
+++ b/features/support/merlin_packet_defaults.rb
@@ -601,6 +601,10 @@ Before do
       "attr" => "0",
       "flags" => "0",
       "type" => "0"
+    },
+    "RUNCMD_PACKET" => {
+      "sd" => "29",
+      "content" => ""
     }
   }
 end

--- a/merlin.spec
+++ b/merlin.spec
@@ -172,6 +172,7 @@ Requires: monitor-livestatus
 Requires: op5-lmd
 Requires: op5-naemon
 Requires: merlin merlin-apps monitor-merlin
+Requires: monitor-testthis
 BuildRequires: diffutils
 
 %description test

--- a/module/module.c
+++ b/module/module.c
@@ -15,6 +15,7 @@
 #include "oconfsplit.h"
 #include "script-helpers.h"
 #include "net.h"
+#include "runcmd.h"
 
 merlin_node **host_check_node = NULL;
 merlin_node **service_check_node = NULL;
@@ -799,6 +800,12 @@ int handle_event(merlin_node *node, merlin_event *pkt)
 	if (pkt->hdr.type == CTRL_PACKET) {
 		handle_control(node, pkt);
 		return 0;
+	}
+	if (pkt->hdr.type == RUNCMD_PACKET) {
+		if (merlin_decode_event(node, pkt)) {
+			return 0;
+		}
+		return handle_runcmd_event(node, pkt);
 	}
 
 	if (node->state != STATE_CONNECTED) {

--- a/module/queries.c
+++ b/module/queries.c
@@ -6,6 +6,8 @@
 #include "testif_qh.h"
 #include <naemon/naemon.h>
 #include <string.h>
+#include "runcmd.h"
+#include "node.h"
 
 static int dump_cbstats(merlin_node *n, int sd)
 {
@@ -77,6 +79,83 @@ static int dump_expired(int sd)
 	return 0;
 }
 
+int runcmd_callback(merlin_node *node, merlin_event *pkt){
+	merlin_runcmd * runcmd = (merlin_runcmd *) pkt->body;
+	nsock_printf_nul(runcmd->sd,
+		"%s", runcmd->content
+	);
+	return 0;
+
+}
+
+static int remote_runcmd(int sd, char *buf, unsigned int len)
+{
+	struct kvvec *kvv;
+	char * node_name;
+	merlin_node * node = NULL;
+	uint i;
+	runcmd_ctx * ctx;
+	merlin_runcmd * runcmd;
+
+	if (0 != prefixcmp(buf, "node=")) {
+		nsock_printf_nul(sd, "outerr=runcmd must start with the node\n");
+		return 1;
+	}
+
+	/* get node name from buffer */
+	kvv = ekvstr_to_kvvec(buf);
+	node_name = kvvec_fetch_str_str(kvv, "node");
+
+	/* get the node */
+	for (i = 0; i < num_nodes; i++) {
+		merlin_node *_node = node_table[i];
+		if (strcmp(node_name, _node->name) == 0) {
+			node = _node;
+			break;
+		}
+	}
+
+	if (node == NULL) {
+		nsock_printf_nul(sd, "outerr=Could not find node: %s does it exist?\n", node_name);
+		return 1;
+	}
+
+	if (!node->encrypted) {
+		nsock_printf_nul(sd, "outerr=Encryption must be enbled to use SSH-less test this check on nodes with connect set to no\n");
+		return 1;
+	}
+
+	/* Filter away the node name from the command */
+	buf = strchr(buf, ';') + 1;
+
+	/* Destroy/free kvvec */
+	kvvec_destroy(kvv, KVVEC_FREE_ALL);
+
+	/* set runcmd */
+	runcmd = malloc(sizeof(*runcmd));
+	if (runcmd == NULL) {
+		nsock_printf_nul(sd, "outerr=Failed to malloc runcmd");
+		return 0;
+	}
+	runcmd->sd = sd;
+	runcmd->content = strdup(buf);
+
+	/* set the context */
+	ctx = malloc(sizeof(*ctx));
+	if (runcmd == NULL) {
+		nsock_printf_nul(sd, "outerr=Failed to malloc runcmd context");
+		free(runcmd);
+		return 0;
+	}
+	ctx->node = node;
+	ctx->runcmd = runcmd;
+	ctx->type = RUNCMD_CMD;
+
+	schedule_event(0, send_runcmd_cmd, ctx);
+	return 0;
+}
+
+
 /* Our primary query handler */
 int merlin_qh(int sd, char *buf, unsigned int len)
 {
@@ -112,6 +191,10 @@ int merlin_qh(int sd, char *buf, unsigned int len)
 	}
 	if (0 == strcmp(buf, "notify-stats")) {
 		dump_notify_stats(sd);
+		return 0;
+	}
+	if (0 == prefixcmp(buf, "runcmd ")) {
+		remote_runcmd(sd, buf+7, len);
 		return 0;
 	}
 

--- a/module/queries.c
+++ b/module/queries.c
@@ -79,6 +79,7 @@ static int dump_expired(int sd)
 	return 0;
 }
 
+/* Called when a node recieves a RUNCMD_RESP packet. Output is printed to socket */
 int runcmd_callback(merlin_node *node, merlin_event *pkt){
 	merlin_runcmd * runcmd = (merlin_runcmd *) pkt->body;
 	nsock_printf_nul(runcmd->sd,
@@ -88,6 +89,7 @@ int runcmd_callback(merlin_node *node, merlin_event *pkt){
 
 }
 
+/* runc query handler for requesting a remote node to run a runcmd command */
 static int remote_runcmd(int sd, char *buf, unsigned int len)
 {
 	struct kvvec *kvv;

--- a/module/queries.c
+++ b/module/queries.c
@@ -110,9 +110,8 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 
 	/* get the node */
 	for (i = 0; i < num_nodes; i++) {
-		merlin_node *_node = node_table[i];
-		if (strcmp(node_name, _node->name) == 0) {
-			node = _node;
+		if (strcmp(node_name, node_table[i]->name) == 0) {
+			node = node_table[i];
 			break;
 		}
 	}
@@ -127,8 +126,18 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 		return 1;
 	}
 
+	if (node->state != STATE_CONNECTED) {
+		nsock_printf_nul(sd, "outerr=Node %s in not connected\n", node->name);
+		return 1;
+	}
+
 	/* Filter away the node name from the command */
-	buf = strchr(buf, ';') + 1;
+	buf = strchr(buf, ';');
+	if (buf == NULL) {
+		nsock_printf_nul(sd, "outerr=Error while parsing command\n");
+		return 1;
+	}
+	buf = buf + 1;
 
 	/* Destroy/free kvvec */
 	kvvec_destroy(kvv, KVVEC_FREE_ALL);

--- a/module/queries.c
+++ b/module/queries.c
@@ -100,7 +100,7 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 	merlin_runcmd * runcmd;
 
 	if (0 != prefixcmp(buf, "node=")) {
-		nsock_printf_nul(sd, "outerr=runcmd must start with the node\n");
+		nsock_printf_nul(sd, "outstd=runcmd must start with the node\n");
 		return 1;
 	}
 
@@ -117,24 +117,24 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 	}
 
 	if (node == NULL) {
-		nsock_printf_nul(sd, "outerr=Could not find node: %s does it exist?\n", node_name);
+		nsock_printf_nul(sd, "outstd=Could not find node: %s does it exist?\n", node_name);
 		return 1;
 	}
 
 	if (!node->encrypted) {
-		nsock_printf_nul(sd, "outerr=Encryption must be enbled to use SSH-less test this check on nodes with connect set to no\n");
+		nsock_printf_nul(sd, "outstd=Encryption must be enbled to use SSH-less test this check on nodes with connect set to no\n");
 		return 1;
 	}
 
 	if (node->state != STATE_CONNECTED) {
-		nsock_printf_nul(sd, "outerr=Node %s in not connected\n", node->name);
+		nsock_printf_nul(sd, "outstd=Node %s in not connected\n", node->name);
 		return 1;
 	}
 
 	/* Filter away the node name from the command */
 	buf = strchr(buf, ';');
 	if (buf == NULL) {
-		nsock_printf_nul(sd, "outerr=Error while parsing command\n");
+		nsock_printf_nul(sd, "outstd=Error while parsing command\n");
 		return 1;
 	}
 	buf = buf + 1;
@@ -145,7 +145,7 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 	/* set runcmd */
 	runcmd = malloc(sizeof(*runcmd));
 	if (runcmd == NULL) {
-		nsock_printf_nul(sd, "outerr=Failed to malloc runcmd");
+		nsock_printf_nul(sd, "outstd=Failed to malloc runcmd");
 		return 0;
 	}
 	runcmd->sd = sd;
@@ -154,7 +154,7 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 	/* set the context */
 	ctx = malloc(sizeof(*ctx));
 	if (runcmd == NULL) {
-		nsock_printf_nul(sd, "outerr=Failed to malloc runcmd context");
+		nsock_printf_nul(sd, "outstd=Failed to malloc runcmd context");
 		free(runcmd);
 		return 0;
 	}

--- a/module/queries.h
+++ b/module/queries.h
@@ -1,6 +1,9 @@
 #ifndef INCLUDE_queries_h__
 #define INCLUDE_queries_h__
 
+#include "node.h"
+
 int merlin_qh(int sd, char *buf, unsigned int len);
+int runcmd_callback(merlin_node *node, merlin_event *pkt);
 
 #endif

--- a/module/runcmd.c
+++ b/module/runcmd.c
@@ -1,0 +1,109 @@
+#include "shared.h"
+#include "module.h"
+#include "logging.h"
+#include <naemon/naemon.h>
+#include <string.h>
+#include "runcmd.h"
+#include "queries.h"
+#include "ipc.h"
+#include "codec.h"
+
+void send_runcmd_cmd(struct nm_event_execution_properties *evprop) {
+	runcmd_ctx * ctx = (runcmd_ctx *) evprop->user_data;
+	merlin_event pkt;
+	merlin_node * node = ctx->node;
+
+	memset(&pkt, 0, sizeof(merlin_event));
+	memset(&pkt.hdr, 0, HDR_SIZE);
+
+	pkt.hdr.sig.id = MERLIN_SIGNATURE;
+	pkt.hdr.protocol = MERLIN_PROTOCOL_VERSION;
+	gettimeofday(&pkt.hdr.sent, NULL);
+	pkt.hdr.type = RUNCMD_PACKET;
+	pkt.hdr.code = ctx->type;
+	pkt.hdr.len = merlin_encode_event(&pkt, (void *)ctx->runcmd);
+
+	if (pkt.hdr.len > sizeof(pkt.body)) {
+		lerr("RUNCMD: Attempted to send %u bytes of data when max is %u",
+			 pkt.hdr.len, sizeof(pkt.body));
+		free(ctx->runcmd);
+		free(ctx);
+		return;
+	}
+
+	node_send(node, &pkt, packet_size(&pkt), MSG_DONTWAIT);
+	free(ctx->runcmd);
+	free(ctx);
+}
+
+void runcmd_wproc_callback(wproc_result *wpres, void * arg, int flags) {
+	runcmd_ctx * ctx = (runcmd_ctx *) arg;
+	struct nm_event_execution_properties evprop;
+	/* Overwrite the ctx with response values */
+	ctx->type = RUNCMD_RESP;
+	if (wpres != NULL) {
+		char * buf = kvvec_fetch_str_str(wpres->response, "outstd");
+		ctx->runcmd->content = buf;
+	} else {
+		ctx->runcmd->content = strdup("Failed to get command");
+	}
+	evprop.user_data = (void *) ctx;
+	send_runcmd_cmd(&evprop);
+}
+
+int handle_runcmd_event(merlin_node *node, merlin_event *pkt) {
+	if (pkt->hdr.code == RUNCMD_CMD) {
+		/* Execute and return send RESP packet back */
+		runcmd_ctx * ctx;
+		merlin_runcmd * runcmd = (merlin_runcmd *) pkt->body;
+		char * full_cmd;
+		size_t full_cmd_sz;
+		char * cmd_prefix = "/usr/bin/mon qh query --single '@runcmd run ";
+		int ret;
+
+		ldebug("RUNCMD: Got RUNCMD_CMD packet from: %s", node->name);
+
+		/* Need to re-malloc these as they would otherwise be free'd later on */
+		/* These will eventually be free'd in send_runcmd_cmd */
+		ctx = malloc(sizeof(*ctx));
+		if (ctx == NULL) {
+			lerr("RUNCMD: Failed to malloc context");
+			return 0;
+		}
+		ctx->runcmd = malloc(sizeof(merlin_runcmd));
+		ctx->runcmd->content = strdup(runcmd->content);
+		ctx->runcmd->sd = runcmd->sd;
+		ctx->node = node;
+
+		/* size of full command, plus one for additional end quote and one for null terminator */
+		full_cmd_sz=strlen(cmd_prefix) + strlen(ctx->runcmd->content)+2;
+		full_cmd = malloc(full_cmd_sz);
+		if (full_cmd == NULL) {
+			lerr("RUNCMD: failed to malloc full_cmd");
+			free(ctx->runcmd);
+			free(ctx);
+			return 0;
+		}
+		ret = snprintf(full_cmd, full_cmd_sz, "%s%s'", cmd_prefix, ctx->runcmd->content);
+		if (ret < 0) {
+			lerr("RUNCMD: could not generate full command");
+			free(ctx->runcmd);
+			free(ctx);
+			free(full_cmd);
+			return 0;
+		}
+		ldebug("RUNCMD: Full QH query: \n%s", full_cmd);
+		wproc_run_callback(full_cmd, 5, runcmd_wproc_callback, (void*)ctx, 0);
+		free(full_cmd);
+		return 0;
+	} else if (pkt->hdr.code == RUNCMD_RESP) {
+		/* Callback to query handler */
+		ldebug("RUNCMD: Got RUNCMD_RESP packet from: %s", node->name);
+		return runcmd_callback(node, pkt);
+	}
+	else {
+		/* Unknown code? */
+		lwarn("RUNCMD: Got unkown RUNCMD type");
+		return 0;
+	}
+}

--- a/module/runcmd.h
+++ b/module/runcmd.h
@@ -11,7 +11,9 @@ struct runcmd_ctx {
 };
 typedef struct runcmd_ctx runcmd_ctx;
 
+/* Sends a RUNCMD_PACKET */
 void send_runcmd_cmd(struct nm_event_execution_properties *evprop);
+/* Handles incoming RUNCMD_PACKETs */
 int handle_runcmd_event(merlin_node *node, merlin_event *pkt);
 
 #endif

--- a/module/runcmd.h
+++ b/module/runcmd.h
@@ -4,7 +4,6 @@
 #include "node.h"
 
 struct runcmd_ctx {
-  /* char * content; */
   struct merlin_runcmd * runcmd;
   struct merlin_node * node;
   uint16_t type;

--- a/module/runcmd.h
+++ b/module/runcmd.h
@@ -1,0 +1,17 @@
+#ifndef INCLUDE_runcmd_h__
+#define INCLUDE_runcmd_h__
+
+#include "node.h"
+
+struct runcmd_ctx {
+  /* char * content; */
+  struct merlin_runcmd * runcmd;
+  struct merlin_node * node;
+  uint16_t type;
+};
+typedef struct runcmd_ctx runcmd_ctx;
+
+void send_runcmd_cmd(struct nm_event_execution_properties *evprop);
+int handle_runcmd_event(merlin_node *node, merlin_event *pkt);
+
+#endif

--- a/shared/codec.c
+++ b/shared/codec.c
@@ -329,7 +329,6 @@ int merlin_decode(void *ds, off_t len, int cb_type)
 		/* calloc to ensure we 0 initialize */
 		ptrs = calloc(7,sizeof(off_t));
 		ptrs[0] = offsetof(merlin_runcmd, content);
-		ldebug("merlin_decode: RUNCMD_PACKET");
 	}
 	else if (!ds || !len || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
 		return -1;
@@ -369,6 +368,5 @@ int merlin_decode(void *ds, off_t len, int cb_type)
 	if (cb_type == RUNCMD_PACKET) {
 		free(ptrs);
 	}
-	ldebug("merlin_decode: return value: %d", ret);
 	return ret;
 }

--- a/shared/codec.c
+++ b/shared/codec.c
@@ -221,20 +221,28 @@ int merlin_encode(void *data, int cb_type, char *buf, int buflen)
 	int i, len, num_strings;
 	off_t offset, *ptrs;
 
-	if (!data || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
+	if (cb_type == RUNCMD_PACKET && data != NULL) {
+		offset = sizeof(merlin_runcmd);
+		num_strings = 1;
+
+		/* calloc to ensure we 0 initialize */
+		ptrs = calloc(7,sizeof(off_t));
+		ptrs[0] = offsetof(merlin_runcmd, content);
+	}
+	else if (!data || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
 		return 0;
-
-	/*
-	 * offset points to where we should write, based off of
-	 * the base location of the block we're writing into.
-	 * Here, we set it to write to the first byte in pkt->body
-	 * not occupied with the binary data that makes up the
-	 * struct itself.
-	 */
-	offset = hook_info[cb_type].offset;
-	num_strings = hook_info[cb_type].strings;
-	ptrs = hook_info[cb_type].ptrs;
-
+	else {
+		/*
+		 * offset points to where we should write, based off of
+		 * the base location of the block we're writing into.
+		 * Here, we set it to write to the first byte in pkt->body
+		 * not occupied with the binary data that makes up the
+		 * struct itself.
+		 */
+		offset = hook_info[cb_type].offset;
+		num_strings = hook_info[cb_type].strings;
+		ptrs = hook_info[cb_type].ptrs;
+	}
 	/*
 	 * copy the base struct first. We'll overwrite the string
 	 * positions later on.
@@ -293,6 +301,9 @@ int merlin_encode(void *data, int cb_type, char *buf, int buflen)
 	if (offset % 8)
 		offset += 8 - offset % 8;
 
+	if (cb_type == RUNCMD_PACKET) {
+		free(ptrs);
+	}
 	return offset;
 }
 
@@ -312,11 +323,20 @@ int merlin_decode(void *ds, off_t len, int cb_type)
 	off_t *ptrs;
 	int num_strings, i, ret = 0;
 
-	if (!ds || !len || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
-		return -1;
+	if (cb_type == RUNCMD_PACKET && ds && len) {
+		num_strings = 1;
 
-	num_strings = hook_info[cb_type].strings;
-	ptrs = hook_info[cb_type].ptrs;
+		/* calloc to ensure we 0 initialize */
+		ptrs = calloc(7,sizeof(off_t));
+		ptrs[0] = offsetof(merlin_runcmd, content);
+		ldebug("merlin_decode: RUNCMD_PACKET");
+	}
+	else if (!ds || !len || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
+		return -1;
+	else {
+		num_strings = hook_info[cb_type].strings;
+		ptrs = hook_info[cb_type].ptrs;
+	}
 
 	for (i = 0; i < num_strings; i++) {
 		char *ptr;
@@ -346,6 +366,9 @@ int merlin_decode(void *ds, off_t len, int cb_type)
 		/* now write it back to the proper location */
 		memcpy((char *)ds + ptrs[i], &ptr, sizeof(ptr));
 	}
-
+	if (cb_type == RUNCMD_PACKET) {
+		free(ptrs);
+	}
+	ldebug("merlin_decode: return value: %d", ret);
 	return ret;
 }

--- a/shared/node.h
+++ b/shared/node.h
@@ -47,6 +47,7 @@
 #define CTRL_PACKET   0xffff  /* control packet. "code" described below */
 #define ACK_PACKET    0xfffe  /* ACK ("I understood") (not used) */
 #define NAK_PACKET    0xfffd  /* NAK ("I don't understand") (not used) */
+#define RUNCMD_PACKET 0xfffc  /* Used from runcmd pkts for "test this" */
 
 /* If "type" is CTRL_PACKET, then "code" is one of the following */
 #define CTRL_GENERIC  0 /* generic control packet */
@@ -57,6 +58,8 @@
 #define CTRL_STALL    5 /* (deprecated) signal that we can't accept events for a while */
 #define CTRL_RESUME   6 /* (deprecated) now we can accept events again */
 #define CTRL_STOP     7 /* exit() immediately (only accepted via ipc) */
+#define RUNCMD_CMD    8 /* Used for requesting a command to be run */
+#define RUNCMD_RESP   9 /* response of a command execution */
 /* the following magic entries can be used for the "code" entry */
 #define MAGIC_NONET 0xffff /* don't forward to the network */
 
@@ -256,6 +259,12 @@ struct merlin_node {
 	unsigned char privkey[crypto_box_SECRETKEYBYTES];
 	unsigned char sharedkey[crypto_box_BEFORENMBYTES];
 };
+
+struct merlin_runcmd {
+  int sd;
+  char * content;
+} __attribute__((packed));
+typedef struct merlin_runcmd merlin_runcmd;
 
 #define node_table noc_table
 extern merlin_node **noc_table, **peer_table, **poller_table;

--- a/test_protocol/merlinpkt.py
+++ b/test_protocol/merlinpkt.py
@@ -3,6 +3,7 @@ import struct
 CTRL_PACKET   = 0xffff
 ACK_PACKET    = 0xfffe
 NAK_PACKET    = 0xfffd
+RUNCMD_PACKET = 0xfffc
 
 CTRL_GENERIC  = 0
 CTRL_PULSE    = 1

--- a/tests/merlincat/generate-nebev2kvvec.py
+++ b/tests/merlincat/generate-nebev2kvvec.py
@@ -266,6 +266,10 @@ event_structs = {
 		'uint:host_checks_handled',
 		'uint:service_checks_handled',
 		'uint:monitored_object_state_size',
+	],
+	'merlin_runcmd': [
+		'int:sd',
+		'str:content',
 	]
 }
 

--- a/tests/merlincat/merlincat_codec.c
+++ b/tests/merlincat/merlincat_codec.c
@@ -1,4 +1,5 @@
 #include <shared/shared.h>
+#include <shared/node.h>
 #include "merlincat_codec.h"
 #include <string.h>
 
@@ -224,20 +225,28 @@ int merlincat_encode(gpointer data, int cb_type, gpointer buf, gsize buflen)
 	int i, len, num_strings;
 	off_t offset, *ptrs;
 
-	if (!data || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
+	if (cb_type == RUNCMD_PACKET && data != NULL) {
+		offset = sizeof(merlin_runcmd);
+		num_strings = 1;
+
+		/* calloc to ensure we 0 initialize */
+		ptrs = calloc(7,sizeof(off_t));
+		ptrs[0] = offsetof(merlin_runcmd, content);
+	}
+	else if (!data || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
 		return 0;
-
-	/*
-	 * offset points to where we should write, based off of
-	 * the base location of the block we're writing into.
-	 * Here, we set it to write to the first byte in pkt->body
-	 * not occupied with the binary data that makes up the
-	 * struct itself.
-	 */
-	offset = hook_info[cb_type].offset;
-	num_strings = hook_info[cb_type].strings;
-	ptrs = hook_info[cb_type].ptrs;
-
+	else {
+		/*
+		 * offset points to where we should write, based off of
+		 * the base location of the block we're writing into.
+		 * Here, we set it to write to the first byte in pkt->body
+		 * not occupied with the binary data that makes up the
+		 * struct itself.
+		 */
+		offset = hook_info[cb_type].offset;
+		num_strings = hook_info[cb_type].strings;
+		ptrs = hook_info[cb_type].ptrs;
+	}
 	/*
 	 * copy the base struct first. We'll overwrite the string
 	 * positions later on.
@@ -300,6 +309,10 @@ int merlincat_encode(gpointer data, int cb_type, gpointer buf, gsize buflen)
 	if (offset % 8)
 		offset += 8 - offset % 8;
 
+	if (cb_type == RUNCMD_PACKET) {
+		free(ptrs);
+	}
+
 	return offset;
 }
 
@@ -319,11 +332,19 @@ int merlincat_decode(gpointer ds, gsize len, int cb_type)
 	off_t *ptrs;
 	int num_strings, i, ret = 0;
 
-	if (!ds || !len || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
-		return -1;
+	if (cb_type == RUNCMD_PACKET && ds && len) {
+		num_strings = 1;
 
-	num_strings = hook_info[cb_type].strings;
-	ptrs = hook_info[cb_type].ptrs;
+		/* calloc to ensure we 0 initialize */
+		ptrs = calloc(7,sizeof(off_t));
+		ptrs[0] = offsetof(merlin_runcmd, content);
+	}
+	else if (!ds || !len || cb_type < 0 || cb_type >= NEBCALLBACK_NUMITEMS)
+		return -1;
+	else {
+		num_strings = hook_info[cb_type].strings;
+		ptrs = hook_info[cb_type].ptrs;
+	}
 
 	for (i = 0; i < num_strings; i++) {
 		char *ptr;
@@ -355,6 +376,9 @@ int merlincat_decode(gpointer ds, gsize len, int cb_type)
 
 		/* now write it back to the proper location */
 		memcpy((char *)ds + ptrs[i], &ptr, sizeof(ptr));
+	}
+	if (cb_type == RUNCMD_PACKET) {
+		free(ptrs);
 	}
 
 	return ret;


### PR DESCRIPTION
With this commit we implement a SSH-less `test this check`. A new merlin
QH type is added as well as a new merlin pkt, `RUNCMD_PACKET`.

Using the new QH type, we can send a request to a remote node to execute
a query via the 'testthis' query handler, and the remote node should
respond with the result.

This is part of: MON-12394

Signed-off-by: Jacob Hansen <jhansen@op5.com>