### PR TITLE
Enable setting publickey when adding a new node

### DIFF
--- a/apps/libexec/modules/merlin_conf.py
+++ b/apps/libexec/modules/merlin_conf.py
@@ -57,7 +57,7 @@ class merlin_node:
 	def write(self, f):
 		oconf_vars = {}
 		f.write("%s %s {\n" % (self.ntype, self.name))
-		valid_vars = ['address', 'port', 'connect', 'uuid']
+		valid_vars = ['address', 'port', 'connect', 'uuid', 'publickey']
 		if self.ntype == 'poller':
 			valid_vars.append('hostgroup')
 			valid_vars.append('hostgroups')
@@ -73,6 +73,8 @@ class merlin_node:
 				continue
 			if type(v) == type([]):
 				v = ','.join(v)
+			if k == "publickey":
+			    f.write("\tencrypted = 1\n")
 
 			# we store and print oconf variables specially
 			f.write("\t%s = %s\n" % (k, v))


### PR DESCRIPTION
With this commit `publickey` is added to the list of options which
can be set when adding a new node, this will enable a user to set up
a new encrypted node without having to edit the merlin configuration
file directly.

Signed-off-by: Erik Sjöström <esjostrom@op5.com>