### PR TITLE
Slim poller: Support auto updating

### DIFF
--- a/apps/libexec/oconf.py.in
+++ b/apps/libexec/oconf.py.in
@@ -251,6 +251,8 @@ def cmd_fetch(args):
     if errors != 0:
         print "Errors occured while synchronizing files!"
         sys.exit(1)
+    # Restart this node after config files has been fetch
+    sp.call("sudo mon restart", shell=True)
     sys.exit(0)
 
 

--- a/features/cluster_update.feature
+++ b/features/cluster_update.feature
@@ -1,0 +1,37 @@
+@config @daemons @merlin @queryhandler
+Feature: The cluster_update functionality allows to configure a specific script
+	to be run when a node has an incompatible cluster configuration.
+
+	Background: I some default configuration in naemon
+		Given I have naemon hostgroup objects
+			| hostgroup_name | alias |
+			| pollergroup    | PG    |
+		And I have naemon host objects
+			| use          | host_name | address   | hostgroups  |
+			| default-host | something | 127.0.0.1 | pollergroup |
+		And I have naemon service objects
+			| use             | host_name | description |
+			| default-service | something | PING        |
+
+	Scenario: Master sends CTRL_INVALID_CLUSTER then the poller should
+		execute the cluster_update command
+		Given I start naemon with merlin nodes connected
+			| type   | name    | port |
+			| master | master1 | 4001 |
+		And master1 sends event CTRL_INVALID_CLUSTER
+			| version | 1 |
+
+		And I wait for 3 second
+		Then file merlin.log matches Cluster update finished successfully
+
+	Scenario: If poller connects with wrong number of peers it should
+		disconnect.
+		Given I start naemon with merlin nodes connected
+			| type   | name    | port | hostgroups  |
+			| poller | poller1 | 4001 | pollergroup |
+		And poller1 sends event CTRL_ACTIVE
+			| configured_peers    | 1 |
+			| configured_masters  | 2 |
+
+		And I wait for 1 second
+		Then poller1 should appear disconnected

--- a/features/step_definitions/service_startup.rb
+++ b/features/step_definitions/service_startup.rb
@@ -82,6 +82,7 @@ Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
     module {
       log_file = merlin.log;
       notifies = #{@merlinnodeconfig.get_var("notifies")};
+      cluster_update = echo dummy
     }
     daemon {
       pidfile = merlin.pid;

--- a/features/support/merlin_packet_defaults.rb
+++ b/features/support/merlin_packet_defaults.rb
@@ -605,6 +605,25 @@ Before do
     "RUNCMD_PACKET" => {
       "sd" => "29",
       "content" => ""
-    }
+    },
+    "CTRL_INVALID_CLUSTER" => {
+      "version" => "1",
+      "word_size" => "64",
+      "byte_order" => "1234",
+      "object_structure_version" => "402",
+      "start" => "1446586100.291601", # About 3 nov 2015
+      "last_cfg_change" => "17",
+      "config_hash" => "my_hash",
+      "peer_id" => "0",
+      "active_peers" => "0",
+      "configured_peers" => "0",
+      "active_pollers" => "0",
+      "configured_pollers" => "0",
+      "active_masters" => "0",
+      "configured_masters" => "0",
+      "host_checks_handled" => "4",
+      "service_checks_handled" => "92",
+      "monitored_object_state_size" => "408"
+    },
   }
 end

--- a/module/module.h
+++ b/module/module.h
@@ -54,6 +54,8 @@ extern node_selection *node_selection_by_hostname(const char *name);
 /** global variables exported by Nagios **/
 extern int __nagios_object_structure_version;
 
+extern char * cluster_update;
+
 /** prototypes **/
 extern void schedule_expiration_event(int type, merlin_node *node, void *obj);
 extern int handle_ipc_event(merlin_node *node, merlin_event *pkt);

--- a/module/script-helpers.c
+++ b/module/script-helpers.c
@@ -12,6 +12,7 @@
 #include "configuration.h"
 #include "shared.h"
 #include "script-helpers.h"
+#include "module.h"
 
 
 static void log_child_output(const char *prefix, char *buf)
@@ -217,4 +218,12 @@ void csync_node_active(merlin_node *node, const merlin_nodeinfo *info, int tdelt
 		child->is_running = 1;
 		wproc_run_callback(child->cmd, 600, handle_csync_finished, child, NULL);
 	}
+}
+
+static void handle_cluster_update_finished(wproc_result *wpres, void *arg, int flags) {
+	log_child_result(wpres, "Cluster update");
+}
+
+void update_cluster_config() {
+	wproc_run_callback(cluster_update, 60, handle_cluster_update_finished, NULL, 0);
 }

--- a/module/script-helpers.h
+++ b/module/script-helpers.h
@@ -3,4 +3,5 @@
 #include "node.h"
 int import_objects(char *cfg, char *cache);
 void csync_node_active(merlin_node *node, const merlin_nodeinfo *info, int delta);
+void update_cluster_config(void);
 #endif

--- a/shared/node.c
+++ b/shared/node.c
@@ -380,7 +380,8 @@ static void create_node_tree(merlin_node *table, unsigned n)
 	xnoc = xpeer = xpoll = 0;
 	for (i = 0; i < n; i++) {
 		merlin_node *node = &table[i];
-
+		
+		node->incompatible_cluster_config = false;
 		switch (node->type) {
 		case MODE_NOC:
 			node->id = xnoc;
@@ -1136,6 +1137,9 @@ int node_ctrl(merlin_node *node, int code, uint selection, void *data,
 		return -1;
 	}
 
+	if (code == CTRL_ACTIVE && node->incompatible_cluster_config) {
+		code = CTRL_INVALID_CLUSTER;
+	} 
 	memset(&pkt.hdr, 0, HDR_SIZE);
 
 	pkt.hdr.sig.id = MERLIN_SIGNATURE;

--- a/shared/node.h
+++ b/shared/node.h
@@ -50,16 +50,17 @@
 #define RUNCMD_PACKET 0xfffc  /* Used from runcmd pkts for "test this" */
 
 /* If "type" is CTRL_PACKET, then "code" is one of the following */
-#define CTRL_GENERIC  0 /* generic control packet */
-#define CTRL_PULSE    1 /* keep-alive signal */
-#define CTRL_INACTIVE 2 /* signals that a slave went offline */
-#define CTRL_ACTIVE   3 /* signals that a slave went online */
-#define CTRL_PATHS    4 /* body contains paths to import */
-#define CTRL_STALL    5 /* (deprecated) signal that we can't accept events for a while */
-#define CTRL_RESUME   6 /* (deprecated) now we can accept events again */
-#define CTRL_STOP     7 /* exit() immediately (only accepted via ipc) */
-#define RUNCMD_CMD    8 /* Used for requesting a command to be run */
-#define RUNCMD_RESP   9 /* response of a command execution */
+#define CTRL_GENERIC		0  /* generic control packet */
+#define CTRL_PULSE		1  /* keep-alive signal */
+#define CTRL_INACTIVE		2  /* signals that a slave went offline */
+#define CTRL_ACTIVE		3  /* signals that a slave went online */
+#define CTRL_PATHS		4  /* body contains paths to import */
+#define CTRL_STALL		5  /* (deprecated) signal that we can't accept events for a while */
+#define CTRL_RESUME		6  /* (deprecated) now we can accept events again */
+#define CTRL_STOP		7  /* exit() immediately (only accepted via ipc) */
+#define CTRL_INVALID_CLUSTER	8 /* signals to a node that it's cluster cfg is invalid */
+#define RUNCMD_CMD		9  /* Used for requesting a command to be run */
+#define RUNCMD_RESP		10  /* response of a command execution */
 /* the following magic entries can be used for the "code" entry */
 #define MAGIC_NONET 0xffff /* don't forward to the network */
 
@@ -262,6 +263,7 @@ struct merlin_node {
 	unsigned char privkey[crypto_box_SECRETKEYBYTES];
 	unsigned char sharedkey[crypto_box_BEFORENMBYTES];
 	char uuid[UUID_SIZE + 1]; /* 36 plus null terminator */
+	bool incompatible_cluster_config;
 };
 
 struct merlin_runcmd {

--- a/shared/shared.c
+++ b/shared/shared.c
@@ -275,6 +275,7 @@ static const char *control_names[] = {
 	CTRL_ENTRY(STALL),
 	CTRL_ENTRY(RESUME),
 	CTRL_ENTRY(STOP),
+	CTRL_ENTRY(INVALID_CLUSTER),
 };
 const char *ctrl_name(uint code)
 {

--- a/tests/merlincat/event_packer.c
+++ b/tests/merlincat/event_packer.c
@@ -470,7 +470,11 @@ merlin_event *event_packer_unpack_kvv(const char *cmd, struct kvvec *kvv) {
 		res = kvvec_to_adaptive_contact(kvv, unpacked_data);
 		break;
 	case CTRL_PACKET:
-		evt->hdr.code = CTRL_ACTIVE; /* Todo: Assume CTRL_ACTIVE */
+		if (0 == strcmp("CTRL_INVALID_CLUSTER", cmd)) {
+			evt->hdr.code = CTRL_INVALID_CLUSTER;
+		} else {
+			evt->hdr.code = CTRL_ACTIVE;
+		}
 		res = kvvec_to_merlin_nodeinfo(kvv, unpacked_data);
 		break;
 	case RUNCMD_PACKET:


### PR DESCRIPTION
With this commit, we add support for a merlin node to run a specific
script, in case a remote node signals that the cluster configuration is
invalid.

To do so, we have a new CTRL command, `INVALID_CLUSTER` which will be
sent when a node connects with incompatible cluster configuration. It
will be sent next time a CTRL_ACTIVE was supposed to be sent. The reason
for this is that we immediately disconnect from a node, when an
incompatible config is seen (i.e before we can manage to send a pkt). However
next time a connection attempt is made, the `CTRL_INVALUD_CLUSTER` packet will
be sent instead of a `CTRL_ACTIVE` pkt as normal.