### PR TITLE
Implement `mon oconf remote-fetch`

### DIFF
--- a/apps/libexec/oconf.py.in
+++ b/apps/libexec/oconf.py.in
@@ -5,6 +5,8 @@ import os
 import io
 import sys
 import subprocess as sp
+import compound_config as cconf
+import nagios_qh
 
 from multiprocessing import Pool
 from compound_config import parse_nagios_cfg
@@ -12,6 +14,7 @@ from merlin_apps_utils import prettyprint_docstring
 
 obj_index = {}
 
+query_socket = False
 
 def idx_get(otype):
     global obj_index
@@ -34,6 +37,7 @@ config_dir = None
 def module_init(args):
     global config_dir
     global cache_dir
+    global query_socket
     rem_args = []
     for arg in args:
         if arg.startswith('--use-helper='):
@@ -46,6 +50,14 @@ def module_init(args):
         rem_args.append(arg)
     if not config_dir:
         config_dir = '%s/config' % cache_dir
+
+    if not query_socket:
+        if os.access(nagios_cfg, os.R_OK):
+            comp = cconf.parse_nagios_cfg(nagios_cfg)
+            query_socket = comp.query_socket
+        else:
+            query_socket = '/opt/monitor/var/rw/nagios.qh'
+
     return rem_args
 
 
@@ -254,6 +266,55 @@ def cmd_fetch(args):
     # Restart this node after config files has been fetch
     sp.call("sudo mon restart", shell=True)
     sys.exit(0)
+
+def cmd_remote_fetch(args):
+    """\
+    [--type=<peer|poller> [<node>]
+    Tells a specific node to fetch split configuration from this node.
+
+    NOTE: A configuration variable called "fetch_name" is
+    required in the object_config section of merlin.cfg on the
+    remote node. The variable should be set to the name of the node,
+    as seen by the master.
+"""
+
+    global query_socket
+    node = ""
+    node_type = ""
+    qh_args = ""
+
+    for arg in args:
+        if arg.startswith('--type='):
+            node_type = arg.split('=')[1]
+        elif arg.startswith('--help'):
+            prettyprint_docstring(
+                'remote-fetch', cmd_remote_fetch.__doc__
+            )
+            sys.exit(1)
+        elif arg.startswith('--'):
+            prettyprint_docstring(
+                'remote-fetch', cmd_remote_fetch.__doc__, 'Unknown argument: %s' % arg
+            )
+            sys.exit(1)
+        else:
+            node = arg
+
+    if node:
+        qh_args += "node=%s;" %node
+    if node_type:
+        qh_args += "type=%s" %node_type
+    if not qh_args:
+        print "No node type or node specified. See `mon oconf remote-fetch help` for more details."
+        return False
+
+    qh = nagios_qh.nagios_qh(query_socket)
+    res = qh.query('#merlin remote-fetch ' + qh_args + '\0')
+    for line in res:
+        print line
+        if qh_args not in line:
+            print line
+
+    return True
 
 
 # Copied and modifed from sync_files

--- a/features/config_sync_passive_poller.feature
+++ b/features/config_sync_passive_poller.feature
@@ -57,3 +57,10 @@ Feature: Module should handle conf sync with poller
 		Then master is not connected to merlin
 		And file merlin.log matches fetch triggered
 		And file config_sync.log does not match ^push
+
+	Scenario: poller should fetch if master sends CTRL_FETCH
+		Given master connect to merlin at port 7000 from port 11001
+		And master sends event CTRL_FETCH
+			| configured_masters |                    1 |
+		When I wait for 1 second
+		Then file merlin.log matches fetch triggered

--- a/features/support/merlin_packet_defaults.rb
+++ b/features/support/merlin_packet_defaults.rb
@@ -625,5 +625,24 @@ Before do
       "service_checks_handled" => "92",
       "monitored_object_state_size" => "408"
     },
+    "CTRL_FETCH" => {
+      "version" => "1",
+      "word_size" => "64",
+      "byte_order" => "1234",
+      "object_structure_version" => "402",
+      "start" => "1446586100.291601", # About 3 nov 2015
+      "last_cfg_change" => "17",
+      "config_hash" => "my_hash",
+      "peer_id" => "0",
+      "active_peers" => "0",
+      "configured_peers" => "0",
+      "active_pollers" => "0",
+      "configured_pollers" => "0",
+      "active_masters" => "0",
+      "configured_masters" => "0",
+      "host_checks_handled" => "4",
+      "service_checks_handled" => "92",
+      "monitored_object_state_size" => "408"
+    },
   }
 end

--- a/module/module.c
+++ b/module/module.c
@@ -405,6 +405,9 @@ void handle_control(merlin_node *node, merlin_event *pkt)
 			update_cluster_config();
 		}
 		break;
+	case CTRL_FETCH:
+		csync_fetch(node);
+		break;
 	case CTRL_STALL:
 	case CTRL_RESUME:
 		linfo("Received (and ignoring) CTRL_{STALL,RESUME} event.");

--- a/module/script-helpers.h
+++ b/module/script-helpers.h
@@ -3,5 +3,6 @@
 #include "node.h"
 int import_objects(char *cfg, char *cache);
 void csync_node_active(merlin_node *node, const merlin_nodeinfo *info, int delta);
+void csync_fetch(merlin_node *node);
 void update_cluster_config(void);
 #endif

--- a/shared/node.h
+++ b/shared/node.h
@@ -58,9 +58,11 @@
 #define CTRL_STALL		5  /* (deprecated) signal that we can't accept events for a while */
 #define CTRL_RESUME		6  /* (deprecated) now we can accept events again */
 #define CTRL_STOP		7  /* exit() immediately (only accepted via ipc) */
-#define CTRL_INVALID_CLUSTER	8 /* signals to a node that it's cluster cfg is invalid */
-#define RUNCMD_CMD		9  /* Used for requesting a command to be run */
-#define RUNCMD_RESP		10  /* response of a command execution */
+#define CTRL_INVALID_CLUSTER	8  /* signals to a node that it's cluster cfg is invalid */
+#define CTRL_FETCH		9  /* signals to remote node that it should do a mon fetch */
+/* some margin for later CTRL commands */
+#define RUNCMD_CMD		20  /* Used for requesting a command to be run */
+#define RUNCMD_RESP		21  /* response of a command execution */
 /* the following magic entries can be used for the "code" entry */
 #define MAGIC_NONET 0xffff /* don't forward to the network */
 

--- a/shared/shared.c
+++ b/shared/shared.c
@@ -276,6 +276,7 @@ static const char *control_names[] = {
 	CTRL_ENTRY(RESUME),
 	CTRL_ENTRY(STOP),
 	CTRL_ENTRY(INVALID_CLUSTER),
+	CTRL_ENTRY(FETCH),
 };
 const char *ctrl_name(uint code)
 {

--- a/tests/merlincat/event_packer.c
+++ b/tests/merlincat/event_packer.c
@@ -472,7 +472,10 @@ merlin_event *event_packer_unpack_kvv(const char *cmd, struct kvvec *kvv) {
 	case CTRL_PACKET:
 		if (0 == strcmp("CTRL_INVALID_CLUSTER", cmd)) {
 			evt->hdr.code = CTRL_INVALID_CLUSTER;
-		} else {
+		} else if (0 == strcmp("CTRL_FETCH", cmd)) {
+			evt->hdr.code = CTRL_FETCH;
+		}
+		else {
 			evt->hdr.code = CTRL_ACTIVE;
 		}
 		res = kvvec_to_merlin_nodeinfo(kvv, unpacked_data);


### PR DESCRIPTION
This commit implements a new feature, that allows one to tell a remote
node to do a `mon oconf fetch`. For example this is useful if you have a
passive poller and you want it to fetch files from the master (for
example updated custom plugins).

It is achieved by:
- Adding a new control packet: CTRL_FETCH
- Calling the fetch command once above ctrl pkt is recieved
- Adding a query handler that allows one to send a CTRL_FETCH packet
- A utility function on the mon oconf script that calls the qh

This fixes: MON-12424

Signed-off-by: Jacob Hansen <jhansen@op5.com>