### PR TITLE
Cluster-update: rate-limit update interval

### DIFF
--- a/module/module.c
+++ b/module/module.c
@@ -402,7 +402,7 @@ void handle_control(merlin_node *node, merlin_event *pkt)
 		lwarn("Node %s has signalled that the cluster config is invalid", node->name);
 		if (cluster_update != NULL) {
 			ldebug("Running cluster update command");
-			update_cluster_config();
+			update_cluster_config(node);
 		}
 		break;
 	case CTRL_FETCH:

--- a/module/script-helpers.c
+++ b/module/script-helpers.c
@@ -273,6 +273,13 @@ static void handle_cluster_update_finished(wproc_result *wpres, void *arg, int f
 	log_child_result(wpres, "Cluster update");
 }
 
-void update_cluster_config() {
+void update_cluster_config(merlin_node * node) {
+	time_t now = time(NULL);
+	if (node->cluster_update_last_attempt >= now - 30) {
+		ldebug("Cluster Update: Update attempted %lu seconds ago. Waiting at least %lu seconds",
+		       now - node->cluster_update_last_attempt, 30 - (now - node->cluster_update_last_attempt));
+		return;
+	}
+	node->cluster_update_last_attempt = now;
 	wproc_run_callback(cluster_update, 60, handle_cluster_update_finished, NULL, 0);
 }

--- a/module/script-helpers.h
+++ b/module/script-helpers.h
@@ -4,5 +4,5 @@
 int import_objects(char *cfg, char *cache);
 void csync_node_active(merlin_node *node, const merlin_nodeinfo *info, int delta);
 void csync_fetch(merlin_node *node);
-void update_cluster_config(void);
+void update_cluster_config(merlin_node *node);
 #endif

--- a/shared/node.h
+++ b/shared/node.h
@@ -266,6 +266,7 @@ struct merlin_node {
 	unsigned char sharedkey[crypto_box_BEFORENMBYTES];
 	char uuid[UUID_SIZE + 1]; /* 36 plus null terminator */
 	bool incompatible_cluster_config;
+	time_t cluster_update_last_attempt;
 };
 
 struct merlin_runcmd {


### PR DESCRIPTION
In case cluster-update script cannot fix a problem, the script will be
continuously called, and restart the node.

With this commit we rate-limit the cluster-update (on a node basis,
depending on who sends the `CTRL_INVALID_CLUSTER` to every 30 seconds).

This is similar to how it is done for oconf operations.

Signed-off-by: Jacob Hansen <jhansen@op5.com>