### PR TITLE
Fix remote-fetch output

### DIFF
--- a/apps/libexec/oconf.py.in
+++ b/apps/libexec/oconf.py.in
@@ -310,7 +310,6 @@ def cmd_remote_fetch(args):
     qh = nagios_qh.nagios_qh(query_socket)
     res = qh.query('#merlin remote-fetch ' + qh_args + '\0')
     for line in res:
-        print line
         if qh_args not in line:
             print line
 

--- a/module/queries.c
+++ b/module/queries.c
@@ -204,7 +204,6 @@ static int remote_fetch(int sd, char *buf, unsigned int len) {
 
 	if (type_str != NULL) {
 		unsigned int i;
-		nsock_printf_nul(sd, "Unknown node type: %s\n", type_str);
 		if (strcmp(type_str, "poller") == 0) {
 			type=MODE_POLLER;
 		} else if (strcmp(type_str, "master") == 0) {


### PR DESCRIPTION
remote-fetch would always print out unknown type, even if everything was
OK, and we would print the output twice from the `mon` tools.

Both of the above has been fixed with this commit.

Signed-off-by: Jacob Hansen <jhansen@op5.com>