### PR TITLE
Set monitor as owner of merlin conf directory

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -321,6 +321,7 @@ fi
 
 %files
 %defattr(-,root,root)
+%dir %attr(750, %daemon_user, -) %mod_path
 %attr(660, -, %daemon_group) %config(noreplace) %mod_path/merlin.conf
 %_datadir/merlin/sql
 %mod_path/merlind


### PR DESCRIPTION
For Slim Poller 2.0 we need the monitor user to be able to write new
files the the monitor directory. This is needed to be able to add public
keys to the default directory.

Signed-off-by: Jacob Hansen <jhansen@op5.com>