### PR TITLE
Support automatic deletion of inactive nodes

### DIFF
--- a/apps/libexec/modules/merlin_conf.py
+++ b/apps/libexec/modules/merlin_conf.py
@@ -57,7 +57,7 @@ class merlin_node:
 	def write(self, f):
 		oconf_vars = {}
 		f.write("%s %s {\n" % (self.ntype, self.name))
-		valid_vars = ['address', 'port', 'connect', 'uuid', 'publickey']
+		valid_vars = ['address', 'port', 'connect', 'uuid', 'publickey', 'auto_delete']
 		if self.ntype == 'poller':
 			valid_vars.append('hostgroup')
 			valid_vars.append('hostgroups')

--- a/module/module.h
+++ b/module/module.h
@@ -190,4 +190,6 @@ struct tmp_net2mod_data {
 	safe_free(tmp.old_long_plugin_output); \
 	safe_free(tmp.old_perf_data);
 
+#define AUTO_DELETE_BUFFER_SIZE 1024 /* Fixed sized buffer used in auto_delete_nodes  */
+
 #endif /* MRM_MOD_H */

--- a/module/script-helpers.c
+++ b/module/script-helpers.c
@@ -276,3 +276,19 @@ static void handle_cluster_update_finished(wproc_result *wpres, void *arg, int f
 void update_cluster_config() {
 	wproc_run_callback(cluster_update, 60, handle_cluster_update_finished, NULL, 0);
 }
+
+static void handle_auto_delete_finished(wproc_result *wpres, void *arg, int flags) {
+	log_child_result(wpres, "Auto delete");
+}
+
+void auto_delete_node_cmd(char * nodes_to_delete) {
+	char cmd[AUTO_DELETE_BUFFER_SIZE];
+	int ret;
+	ret = snprintf(cmd, sizeof(cmd), "mon node remove %s && sudo mon restart", nodes_to_delete);
+	if (ret < 0 || ret >= AUTO_DELETE_BUFFER_SIZE) {
+		lwarn("AUTO_DELETE_CMD: Couldn't delete nodes due to insufficient buffer size: %d", ret);
+	} else {
+		ldebug("AUTO_DELETE_CMD: Executing \"%s\"", cmd);
+		wproc_run_callback(cmd, 300, handle_auto_delete_finished, NULL, 0);
+	}
+}

--- a/module/script-helpers.h
+++ b/module/script-helpers.h
@@ -5,4 +5,5 @@ int import_objects(char *cfg, char *cache);
 void csync_node_active(merlin_node *node, const merlin_nodeinfo *info, int delta);
 void csync_fetch(merlin_node *node);
 void update_cluster_config(void);
+void auto_delete_node_cmd(char * nodes_to_delete);
 #endif

--- a/shared/node.c
+++ b/shared/node.c
@@ -466,6 +466,7 @@ static void grok_node(struct cfg_comp *c, merlin_node *node)
 	/* some sane defaults */
 	node->data_timeout = pulse_interval * 2;
 	node->encrypted = false;
+	node->auto_delete = 0;
 
 	for (i = 0; i < c->vars; i++) {
 		struct cfg_var *v = c->vlist[i];
@@ -526,6 +527,12 @@ static void grok_node(struct cfg_comp *c, merlin_node *node)
 			}
 			uuid_nodes++;
 			strcpy(node->uuid, v->value);
+		} else if (!strcmp(v->key, "auto_delete")) {
+			char *endptr;
+			node->auto_delete = (unsigned int)strtol(v->value, &endptr, 10);
+			if (*endptr != 0)
+				cfg_error(c, v, "Illegal value for auto_delete: %s\n", v->value);
+			
 		}
 		else if (grok_node_flag(&node->flags, v->key, v->value) < 0) {
 			cfg_error(c, v, "Unknown variable\n");

--- a/shared/node.h
+++ b/shared/node.h
@@ -266,6 +266,7 @@ struct merlin_node {
 	unsigned char sharedkey[crypto_box_BEFORENMBYTES];
 	char uuid[UUID_SIZE + 1]; /* 36 plus null terminator */
 	bool incompatible_cluster_config;
+	unsigned int auto_delete;
 };
 
 struct merlin_runcmd {

--- a/shared/shared.c
+++ b/shared/shared.c
@@ -13,6 +13,7 @@ int debug = 0;  /* doesn't actually do anything right now */
 int is_module = 1; /* the daemon sets this to 0 immediately */
 int pulse_interval = 10; /* seconds between each CTRL_ACTIVE packet sent */
 int node_activity_check_interval = 1; /* seconds between each activity check */
+int node_auto_delete_check_interval = 30; /* seconds between each auto delete check */
 int use_database = 0;
 char *merlin_config_file = NULL;
 merlin_nodeinfo *self = NULL;

--- a/shared/shared.h
+++ b/shared/shared.h
@@ -51,6 +51,7 @@ extern const char *merlin_version;
 extern int is_module;
 extern int pulse_interval;
 extern int node_activity_check_interval;
+extern int node_auto_delete_check_interval;
 extern int debug;
 extern char *binlog_dir;
 extern char *merlin_config_file;


### PR DESCRIPTION
With this commit we can automatically set merlin nodes to be deleted, in
case they have been inactive for more than a specified amount of time.
This is useful for the Slim Poller/auto-registering use-case to handle
failure modes where the poller doesn't cleans up itself (for example if
being evicted).

Signed-off-by: Jacob Hansen <jhansen@op5.com>