### PR TITLE
Apps: Add `notifies` as a valid node attribute

### DIFF
--- a/apps/libexec/modules/merlin_conf.py
+++ b/apps/libexec/modules/merlin_conf.py
@@ -57,7 +57,7 @@ class merlin_node:
 	def write(self, f):
 		oconf_vars = {}
 		f.write("%s %s {\n" % (self.ntype, self.name))
-		valid_vars = ['address', 'port', 'connect']
+		valid_vars = ['address', 'port', 'connect', 'notifies']
 		if self.ntype == 'poller':
 			valid_vars.append('hostgroup')
 			valid_vars.append('hostgroups')


### PR DESCRIPTION
With this commit we add `notifies` to be a valid attribute to set during
`mon node add ...`.

This fixes: MON-12566

Signed-off-by: Jacob Hansen <jhansen@op5.com>