### PR TITLE
UUID: Add tests

### DIFF
--- a/tests/merlincat/event_packer.c
+++ b/tests/merlincat/event_packer.c
@@ -518,7 +518,7 @@ merlin_event *event_packer_unpack_kvv(const char *cmd, struct kvvec *kvv) {
 		}
 		evt->hdr.len = size;
 	}
-
+	strcpy(evt->hdr.from_uuid, "41e3aa75-6885-4890-a254-907326792fa0");
 	free(unpacked_data);
 	return evt;
 }


### PR DESCRIPTION
This commit adds a couple of fairly basic UUID tests. We test that a
connection is sucessfull with a correct UUID and doesn't work with an
incorrect UUID.

This fixes: MON-12464

Signed-off-by: Jacob Hansen <jhansen@op5.com>