### PR TITLE
Add support for Naemon 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ and other useful things.
 ## Requirements ##
 
 Merlin requires Naemon, including its development headers for building.
-Currently, it requires the very latest development version (> 1.0.3) for
-auto-detecting paths to Naemon.
+Currently, it requires version >= 1.2.4.
 
 Other general build requirements: gcc, autoconf, automake, glib-2-devel,
 check-devel, libdbi-devel, libtool, naemon-devel, gperf

--- a/module/oconfsplit.c
+++ b/module/oconfsplit.c
@@ -8,6 +8,7 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <glib.h>
+#include <stdbool.h>
 
 static struct {
 	bitmap *hosts;
@@ -242,7 +243,7 @@ static gboolean nsplit_cache_host(gpointer _name, gpointer _hst, __attribute__((
 			nsplit_cache_contacts(se->contacts);
 			fcache_serviceescalation(fp, se);
 		}
-		destroy_service(tmpsvc);
+		destroy_service(tmpsvc, FALSE);
 	}
 	/* This is a temporary host, which doesn't have back references... ugh */
 	if (tmphst->parent_hosts != NULL) {
@@ -337,7 +338,7 @@ static int nsplit_partial_groups(void)
 			fcache_servicegroup(fp, tmpsg);
 		}
 
-		destroy_servicegroup(tmpsg);
+		destroy_servicegroup(tmpsg, FALSE);
 	}
 	return 0;
 }

--- a/tests/test-hooks.c
+++ b/tests/test-hooks.c
@@ -113,7 +113,7 @@ static void expiration_setup(void)
 static void expiration_teardown(void)
 {
 	destroy_objects_host();
-	destroy_objects_service();
+	destroy_objects_service(TRUE);
 	qh_deinit(queryhandler_socket_path);
 	iobroker_destroy(nagios_iobs, IOBROKER_CLOSE_SOCKETS);
 	nebmodule_deinit(0, 0);


### PR DESCRIPTION
Naemon 1.2.4 changed the function calls to destroy service and
servicegroup objects. This commit changes Merlin oconfsplit code to use
the updated function prototype.

This fixes: MON-12649

Signed-off-by: Jacob Hansen <jhansen@op5.com>