### PR TITLE
Add apache as group of merlin conf dir

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -321,7 +321,7 @@ fi
 
 %files
 %defattr(-,root,root)
-%dir %attr(750, %daemon_user, -) %mod_path
+%dir %attr(750, %daemon_user, %daemon_group) %mod_path
 %attr(660, -, %daemon_group) %config(noreplace) %mod_path/merlin.conf
 %_datadir/merlin/sql
 %mod_path/merlind


### PR DESCRIPTION
Adding apache as the group (rather than root) for the merlin conf dir,
allows the HTTP-API tests to pass.

Signed-off-by: Jacob Hansen <jhansen@op5.com>