### PR TITLE
Changes required for running tests on EL8

### DIFF
--- a/features/step_definitions/database.rb
+++ b/features/step_definitions/database.rb
@@ -2,7 +2,7 @@ require "sequel"
 
 Given(/^I have a database running$/) do
     h = @databaseconfig
-    args = "--log-error=./db.log --log=./general-db.log --datadir=./db/data --socket=./db.sock --pid-file=./db.pid"
+    args = "--log-error=./db.log --general-log=./general-db.log --datadir=./db/data --socket=./db.sock --pid-file=./db.pid"
     # The reason we use the exact path to mysqld here is because it's not in $PATH. The
     # alternative is to use mysqld_safe which is in $PATH but it doesn't terminate when
     # we try to kill it with SIGTERM

--- a/merlin.spec
+++ b/merlin.spec
@@ -182,6 +182,9 @@ Requires: libyaml
 Requires: mariadb-devel
 Requires: ruby-devel
 Requires: python2-nose
+# Required development tools for building gems
+Requires: make automake gcc
+Requires: redhat-rpm-config
 BuildRequires: diffutils
 
 %description test

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -17,14 +17,14 @@ post:
     sudo -u monitor mon test rsync
 
     # Run unit tests
-    nosetests ${VERBOSE:+-v} --nocapture --where apps/libexec/modules
+    nosetests-2 ${VERBOSE:+-v} --nocapture --where apps/libexec/modules
 
     # Verify file permissions after installation
     stat --printf='%U:%G %a' /opt/monitor/op5/merlin/merlin.conf | xargs -I{} test "root:apache 660" = "{}"
 
     # Install requirements for cucumber test
     gem install --no-ri --no-rdoc \
-        cucumber:1.3.6 \
+        cucumber:1.3.18 \
         rspec:2.14.1 \
         parallel:1.13.0 \
         parallel_tests:2.23.0 \

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -17,7 +17,11 @@ post:
     sudo -u monitor mon test rsync
 
     # Run unit tests
-    nosetests-2 ${VERBOSE:+-v} --nocapture --where apps/libexec/modules
+    if [ \$RHEL_VERSION == "8" ]; then
+      nosetests-2 ${VERBOSE:+-v} --nocapture --where apps/libexec/modules
+    else
+      nosetests ${VERBOSE:+-v} --nocapture --where apps/libexec/modules
+    fi
 
     # Verify file permissions after installation
     stat --printf='%U:%G %a' /opt/monitor/op5/merlin/merlin.conf | xargs -I{} test "root:apache 660" = "{}"


### PR DESCRIPTION
* Change the deprecated --log argument to --general-log

* Install development tools needed for building ruby gems

* Change to nosetests-2 since we're explicitly using the python2 version

* Bump cucumber version

Fixes: MON-12609

Signed-off-by: Erik Sjöström <esjostrom@itrsgroup.com>