### PR TITLE
Require PyMySQL on EL8

### DIFF
--- a/apps/libexec/modules/merlin_db.py
+++ b/apps/libexec/modules/merlin_db.py
@@ -1,3 +1,5 @@
+import sys
+
 conn = False
 
 def connect(mconf, reuse_conn=True):
@@ -27,10 +29,13 @@ def connect(mconf, reuse_conn=True):
 	if db_type == 'mysql':
 		try:
 			import MySQLdb as db
-		except:
-			print("Failed to import MySQLdb")
-			print("Install mysqldb-python or MySQLdb-python to make this command work")
-			sys.exit(1)
+		except ImportError:
+			try:
+				import pymysql as db
+			except ImportError:
+				print("Failed to import MySQLdb or PyMySQL")
+				print("Install MySQL-python or python2-PyMySQL to make this command work")
+				sys.exit(1)
 		if db_pass == False:
 			conn = db.connect(host=db_host, user=db_user, db=db_name)
 		else:

--- a/merlin.spec
+++ b/merlin.spec
@@ -126,7 +126,7 @@ Requires: libdbi1
 Requires: python-mysql
 %else
 %if 0%{?rhel} >= 8
-BuildRequires: python2-PyMySQL
+Requires: python2-PyMySQL
 %else
 Requires: MySQL-python
 %endif


### PR DESCRIPTION
In a previous commit we changed our dependency on MySQLdb to a *build
dependency* on PyMySQL for EL8. With this commit we upgrade PyMySQL to a
strict requirement on EL8, so that we can use it in the merlin_db.py
script.

This is part of MON-12644.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>