### PR TITLE
Add unixcat as dependency to merlin-apps

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -132,6 +132,7 @@ Requires: MySQL-python
 %endif
 Requires: libdbi
 %endif
+Requires: unixcat
 Obsoletes: monitor-distributed
 Obsoletes: merlin-apps-slim
 


### PR DESCRIPTION
Define unixcat as a dependency, since it's required for the
"mon query ls" command.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>