### PR TITLE
auto_delete: protect against master takeover

### DIFF
--- a/shared/node.c
+++ b/shared/node.c
@@ -530,10 +530,13 @@ static void grok_node(struct cfg_comp *c, merlin_node *node)
 			strcpy(node->uuid, v->value);
 		} else if (!strcmp(v->key, "auto_delete")) {
 			char *endptr;
-			node->auto_delete = (unsigned int)strtol(v->value, &endptr, 10);
-			if (*endptr != 0)
-				cfg_error(c, v, "Illegal value for auto_delete: %s\n", v->value);
-			
+			if (node->type != MODE_POLLER) {
+				cfg_warn(c,v, "auto_delete is only supported for pollers, ignoring.");
+			} else {
+				node->auto_delete = (unsigned int)strtol(v->value, &endptr, 10);
+				if (*endptr != 0)
+					cfg_error(c, v, "Illegal value for auto_delete: %s\n", v->value);
+			}
 		}
 		else if (grok_node_flag(&node->flags, v->key, v->value) < 0) {
 			cfg_error(c, v, "Unknown variable\n");


### PR DESCRIPTION
With this commit we add a few exceptions to the auto delete
functionality. This is to ensure that a master doesn't end up taking
over checks that should've been done on a slim poller cluster. This is
done by ensuring we:

- Don't delete nodes when there's a full network outage, i.e if we
haven't heard from any pollers in the group for a while, we don't delete
any nodes in that pollergroup.
- Don't ever auto delete a single remaining node in a poller group

-------

We don't actively test auto_delete for peers/masters, so disable it
entirely to ensure we don't get unwanted effects.