### PR TITLE
Implement ipc_blocked_hostgroups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,6 +110,7 @@ shared_sources = $(common_sources) \
 	shared/node.c shared/node.h \
 	shared/codec.c shared/codec.h \
 	shared/binlog.c shared/binlog.h \
+	shared/pgroup.c shared/pgroup.h \
 	shared/configuration.c shared/configuration.h
 
 db_wrap_sources = daemon/sql.c daemon/sql.h daemon/db_wrap.c daemon/db_wrap.h
@@ -128,7 +129,6 @@ module_sources = $(shared_sources) \
 	module/oconfsplit.c module/oconfsplit.h \
 	module/net.c module/net.h \
 	module/runcmd.c module/runcmd.h \
-	shared/pgroup.c shared/pgroup.h \
 	module/testif_qh.c module/testif_qh.h
 daemon_sources = $(shared_sources) $(db_wrap_sources) \
 	daemon/daemonize.c daemon/daemonize.h \

--- a/features/active_checks.feature
+++ b/features/active_checks.feature
@@ -404,3 +404,21 @@ Feature: Active checks
 
 	# Should commands propagate from poller to master?
 	# If so, we should test it here.
+
+	Scenario: A non-distrubuted node shouldn't execute checks for
+		any objects in ipc_blocked_hostgroups.
+		Given I have merlin config ipc_blocked_hostgroups set to pollergroup
+		And I start naemon with merlin nodes connected
+			| type   | name       | port |
+		And I have an empty file checks.log
+
+		When I wait for 5 seconds
+
+		Then file checks.log does not match ^check host hostA$
+		And file checks.log does not match ^check host hostB$
+		And file checks.log does not match ^check service hostA PONG$
+		And file checks.log does not match ^check service hostB PONG$
+		And file merlin.log matches Blocking check execution of hostA
+		And file merlin.log matches Blocking check execution of hostA;PONG
+		And file merlin.log matches Blocking check execution of hostB
+		And file merlin.log matches Blocking check execution of hostB;PONG

--- a/features/step_definitions/service_startup.rb
+++ b/features/step_definitions/service_startup.rb
@@ -67,6 +67,11 @@ end
 Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
   push_cmd = "#!/bin/sh\necho \"push $@\" >> config_sync.log"
   fetch_cmd = "#!/bin/sh\necho \"fetch $@\" >> config_sync.log"
+ 
+  blocked_hostgroups = @merlinnodeconfig.get_var("ipc_blocked_hostgroups") 
+  unless blocked_hostgroups.to_s.strip.empty?
+    blocked_hostgroups = "ipc_blocked_hostgroups = #{blocked_hostgroups}"
+  end
 
   configfile = "
     ipc_socket = test_ipc.sock;
@@ -79,6 +84,7 @@ Given(/^I have merlin configured for port (\d+)$/) do |port, nodes|
     binlog_max_memory_size = #{@merlinnodeconfig.get_var("binlog_max_memory_size")};
     binlog_max_file_size = #{@merlinnodeconfig.get_var("binlog_max_file_size")};
     binlog_persist = #{@merlinnodeconfig.get_var("binlog_persist")};
+    #{blocked_hostgroups}
 
     module {
       log_file = merlin.log;

--- a/features/support/merlin_node_config.rb
+++ b/features/support/merlin_node_config.rb
@@ -7,7 +7,8 @@ class MerlinNodeConfig
       "oconfsplit_dir" => ".",
       "binlog_max_file_size" => "5000",
       "binlog_max_memory_size" => "500",
-      "binlog_persist" => "1"
+      "binlog_persist" => "1",
+      "ipc_blocked_hostgroups" => ""
     }
   end
 

--- a/module/hooks.c
+++ b/module/hooks.c
@@ -338,6 +338,8 @@ static int hook_service_result(merlin_event *pkt, void *data)
 		if (node != &ipc) {
 			/* We're not responsible, so block this check here */
 			return NEBERROR_CALLBACKCANCEL;
+		} else if (node_blocked_hostgroup(node, data, ds->type) == true ) {
+			return NEBERROR_CALLBACKCANCEL;
 		}
 		service_checks.self++;
 		return 0;
@@ -395,6 +397,8 @@ static int hook_host_result(merlin_event *pkt, void *data)
 		schedule_expiration_event(HOST_CHECK, node, h);
 		if (node != &ipc) {
 			/* We're not responsible, so block this check here */
+			return NEBERROR_CALLBACKCANCEL;
+		} else if (node_blocked_hostgroup(node, data, ds->type) == true ) {
 			return NEBERROR_CALLBACKCANCEL;
 		}
 		host_checks.self++;

--- a/module/module.c
+++ b/module/module.c
@@ -1794,6 +1794,8 @@ int nebmodule_deinit(__attribute__((unused)) int flags, __attribute__((unused)) 
 	 * Nagios' command pipe.
 	 */
 	nm_bufferqueue_destroy(ipc.bq);
+	free_objectlist(&ipc.ipc_blocked_hostgroups);
+
 	for (i = 0; i < num_nodes; i++) {
 		struct merlin_node *node = node_table[i];
 		/* Save nodes binlog to file if binlog persistence is enabled */

--- a/shared/ipc.c
+++ b/shared/ipc.c
@@ -8,6 +8,7 @@
 #include "io.h"
 #include "node.h"
 #include "encryption.h"
+#include "pgroup.h"
 
 static int listen_sock = -1; /* for bind() and such */
 static char *ipc_sock_path;
@@ -212,6 +213,25 @@ int ipc_grok_var(char *var, char *val)
 			return 0;
 		}
 		strcpy(ipc.uuid, val);
+
+		return 1;
+	}
+
+	if (!strcmp(var, "ipc_blocked_hostgroups")) {
+		char *token;
+		char * saveptr;
+		const char delim[2] = ",";
+		char * hostgroups = get_sorted_csstr(val);
+
+		// Tokenize the blocked hostgroups into a objectlist (linkedlist)
+		token = strtok_r(hostgroups, delim, &saveptr);
+
+		while (token != NULL) {
+			prepend_object_to_objectlist(&ipc.ipc_blocked_hostgroups, strdup(val));
+			token = strtok_r(NULL, delim, &saveptr);
+		}
+
+		free(hostgroups);
 
 		return 1;
 	}

--- a/shared/node.h
+++ b/shared/node.h
@@ -267,6 +267,7 @@ struct merlin_node {
 	char uuid[UUID_SIZE + 1]; /* 36 plus null terminator */
 	bool incompatible_cluster_config;
 	unsigned int auto_delete;
+	objectlist *ipc_blocked_hostgroups;       /* only used for IPC */
 };
 
 struct merlin_runcmd {
@@ -316,7 +317,7 @@ extern int node_oconf_cmp(const merlin_node *node, const merlin_nodeinfo *info);
 extern int node_mconf_cmp(const merlin_node *node, const merlin_nodeinfo *info);
 extern int node_create_binlog(merlin_node *node);
 extern int node_binlog_read_saved(merlin_node *node);
-
+extern bool node_blocked_hostgroup(const merlin_node *node, void * data, int type);
 /*
  * we make these inlined rather than macros so the compiler
  * does type-checking in the arguments

--- a/shared/pgroup.c
+++ b/shared/pgroup.c
@@ -491,7 +491,7 @@ static int cmpstringp(const void *p1, const void *p2)
  * returns a sorted version of a comma-separated string, with
  * spaces surrounding commas removed
  */
-static char *get_sorted_csstr(const char *orig_str)
+char *get_sorted_csstr(const char *orig_str)
 {
 	char *str, *comma, *ret = NULL, **ary, *next;
 	unsigned int i = 0, entries = 0, len;

--- a/shared/pgroup.h
+++ b/shared/pgroup.h
@@ -54,4 +54,5 @@ merlin_peer_group *pgroup_by_host_id(unsigned int id);
 merlin_peer_group *pgroup_by_service_id(unsigned int id);
 struct merlin_node *pgroup_host_node(unsigned int id);
 struct merlin_node *pgroup_service_node(unsigned int id);
+char *get_sorted_csstr(const char *orig_str);
 #endif


### PR DESCRIPTION
With this commit a new merlin option, ipc_blocked_hostgroups, is
introduced. This setting expects a comma seperated list of hostgroups.
Any host or service checks defined in this list will be blocked from
execution on the local node.

No re-assignment of the check is done - meaning the check is only done
if merlin would otherwise schedule the check on another node. This
likely will lead to a significant amount of expired checks, similar to
what would happen if a poller with `takeover=no` is down.

The setting is intended as a safety-net if for some reason your (slim)
pollers are de-registered, and that masters are not supposed/able to
execute checks for specific hostgroups.

This fixes: MON-12802

Signed-off-by: Jacob Hansen <jhansen@op5.com>