### PR TITLE
slim-poller: Don't remove lock file

### DIFF
--- a/apps/libexec/slim-poller.py.in
+++ b/apps/libexec/slim-poller.py.in
@@ -1,4 +1,4 @@
-import fcntl, sys, os
+import fcntl, sys
 import subprocess as sp
 import shlex
 
@@ -103,7 +103,6 @@ def cmd_register(args):
         sys.exit(1)
     finally:
         fcntl.flock(file_descriptor, fcntl.LOCK_UN)
-        os.remove(LOCK_FILE)
 
 
 def cmd_deregister(args):
@@ -143,4 +142,3 @@ def cmd_deregister(args):
         sys.exit(1)
     finally:
         fcntl.flock(file_descriptor, fcntl.LOCK_UN)
-        os.remove(LOCK_FILE)


### PR DESCRIPTION
While removing the actual lock file from the file system looks better,
there is no way to remove it without race conditions. This commit
changes the behaviour to leave the file in place on the file system.

Signed-off-by: Jacob Hansen <jhansen@op5.com>