### PR TITLE
Don't log output to stdout/err during package installation

### DIFF
--- a/merlin.spec
+++ b/merlin.spec
@@ -242,6 +242,12 @@ python2 tests/pyunit/test_oconf.py --verbose
 
 %post
 %create_service_control_function
+
+# Reload the .service file
+%if 0%{?rhel} >= 7
+systemctl daemon-reload
+%endif
+
 # we must stop the merlin deamon so it doesn't interfere with any
 # database upgrades, logfile imports and whatnot
 service_control_function stop merlind > /dev/null || :
@@ -269,7 +275,6 @@ fi
 %_libdir/merlin/install-merlin.sh
 
 %if 0%{?rhel} >= 7
-systemctl daemon-reload
 systemctl enable merlind.service
 %else
 /sbin/chkconfig --add merlind || :

--- a/merlin.spec
+++ b/merlin.spec
@@ -278,8 +278,8 @@ systemctl enable merlind.service
 # If mysql-server is running _or_ this is an upgrade
 # we import logs
 if [ $1 -eq 2 ]; then
-  mon log import --incremental || :
-  mon log import --only-notifications --incremental || :
+  mon log import --incremental > /dev/null || :
+  mon log import --only-notifications --incremental > /dev/null || :
 fi
 
 sed --follow-symlinks -i \


### PR DESCRIPTION
It is best practice not to show output of various commands executed in
i.e post steps of an RPM file. With this commit we ensure output from
the `mon log` commands are hidden. Sometimes this would generate quite a
large output cluttering the update log significantly.

Fixes: MON-12848

----

Previously the first thing we did in the post install step, was to stop
the service. However at this point we installed a new systemd service
file on the system, causing systemctl to warn about the updated file. To
ensure we don't get this warning, we move the `daemon-reload` call up to
before we stop the service