### PR TITLE
Apps: merlinkey add newline when using --write

### DIFF
--- a/apps/libexec/merlinkey.py.in
+++ b/apps/libexec/merlinkey.py.in
@@ -52,6 +52,7 @@ def cmd_generate(args):
 	if write_to_file:
 		with open(merlin_conf_dir + "/merlin.conf", 'a') as fh:
 			fh.write("ipc_privatekey = {}".format(path + "/key.priv"))
+			fh.write('\n')
 
 	uid = pwd.getpwnam("monitor").pw_uid
 	# -1 means we leave group unchanged


### PR DESCRIPTION
When using `mon merlinkey generate --write` the configuration setting
was adding without a newline. This caused future lines to be added at
the end of the same line, instead of on a newline. This in turn created
a corrupt merlin configuration.

Signed-off-by: Jacob Hansen <jhansen@op5.com>