### PR TITLE
Correctly tokenize ipc_blocked_hostgroups

### DIFF
--- a/features/active_checks.feature
+++ b/features/active_checks.feature
@@ -422,3 +422,22 @@ Feature: Active checks
 		And file merlin.log matches Blocking check execution of hostA;PONG
 		And file merlin.log matches Blocking check execution of hostB
 		And file merlin.log matches Blocking check execution of hostB;PONG
+
+	Scenario: A non-distrubuted node shouldn't execute checks for
+		any objects in ipc_blocked_hostgroups. even with multiple
+		hostgroups in ipc_blocked_hostgroups.
+		Given I have merlin config ipc_blocked_hostgroups set to pollergroup, bogus_group
+		And I start naemon with merlin nodes connected
+			| type   | name       | port |
+		And I have an empty file checks.log
+
+		When I wait for 5 seconds
+
+		Then file checks.log does not match ^check host hostA$
+		And file checks.log does not match ^check host hostB$
+		And file checks.log does not match ^check service hostA PONG$
+		And file checks.log does not match ^check service hostB PONG$
+		And file merlin.log matches Blocking check execution of hostA
+		And file merlin.log matches Blocking check execution of hostA;PONG
+		And file merlin.log matches Blocking check execution of hostB
+		And file merlin.log matches Blocking check execution of hostB;PONG

--- a/shared/ipc.c
+++ b/shared/ipc.c
@@ -227,7 +227,7 @@ int ipc_grok_var(char *var, char *val)
 		token = strtok_r(hostgroups, delim, &saveptr);
 
 		while (token != NULL) {
-			prepend_object_to_objectlist(&ipc.ipc_blocked_hostgroups, strdup(val));
+			prepend_object_to_objectlist(&ipc.ipc_blocked_hostgroups, strdup(token));
 			token = strtok_r(NULL, delim, &saveptr);
 		}
 


### PR DESCRIPTION
The logic for tokenizing `ipc_blocked_hostgroups` where broken due to
adding the full input value, rather than the token to the objectlist.
This caused the `ipc_blocked_hostgroups` functionality to be broken when
specifying multiple hostgroups.

Add an additional testcase where we have multiple hostgroups defiend.

Signed-off-by: Jacob Hansen <jhansen@op5.com>