### PR TITLE
op5build: add dependency on livestatus python lib

### DIFF
--- a/op5build/merlin.spec
+++ b/op5build/merlin.spec
@@ -136,6 +136,7 @@ Requires: unixcat
 # php-cli for mon node tree
 Requires: php-cli
 Requires: procps-ng
+Requires: python2-livestatus
 Obsoletes: monitor-distributed
 Obsoletes: merlin-apps-slim
 
@@ -163,6 +164,7 @@ Requires: python3
 # php-cli for mon node tree
 Requires: php-cli
 Requires: procps-ng
+Requires: python2-livestatus
 %if 0%{?rhel} >= 8
 Requires: python3-docopt
 Requires: python3-cryptography


### PR DESCRIPTION
For merlin-apps package, add a requirement on python2-livestatus, which
provides the Livestatus python API for python 2.
Previously it was distributed as part of the main monitor-livestatus
package, but it's now separated to it's own package.

Part of MON-12934.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>
(cherry picked from commit 8fdf1b09e8edb659cd48043c643c96a528429b6e)