### PR TITLE
New node setting "accept_runcmd"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ format YYYY.MM.MICRO. The tag may occasionally be made just prior to the change
 of month.
 
 ## [Unreleased]
+### Changed
+- Encrypted nodes no longer accept runcmds by default. Instead a new configuration
+  option `accept_runcmd` has been introduced which can be set on nodes from which
+  runcmds should be allowed.
 
 ## [2021.11.1] - 2021-11-01
 ### Added

--- a/apps/cluster_tools/cluster_tools.py.in
+++ b/apps/cluster_tools/cluster_tools.py.in
@@ -302,6 +302,7 @@ def add_master(master_name, master_address, poller_name, master_port=15551):
         f"  port = {master_port}\n"
         f"  encrypted = 1\n"
         f"  publickey = {DEFAULT_ENCRYPTION_KEYS_LOCATION}/{master_name}.pub\n"
+        f"  accept_runcmd = 1\n"
         f"  sync {{\n"
         f"    {sync_seperator.join(FILES_TO_SYNC)}\n"
         f"  }}\n"

--- a/docs/merlin.conf.sample
+++ b/docs/merlin.conf.sample
@@ -203,6 +203,10 @@ poller poller1.example.com {
 	# node. Defaults to yes.
 	# connect = yes;
 	#
+	# Specifies whether we accept runcmds from the remote node. Defaults to 0
+	# (disabled).
+	# accept_runcmd = 0;
+	#
 	# Each node may have a custom object_config section, that overwrites the
 	# settings configured in the daemon section. See the daemon section for
 	# details. The below example fetches config from a master, instead of relying

--- a/features/runcmd.feature
+++ b/features/runcmd.feature
@@ -20,12 +20,49 @@ Feature: Test merlins runcmd feature.
 			| default-contact | myContact    |
 
 
-	Scenario: The peer sends a request to "ipc" to execute a RUNCMD command.
+	@unencrypted
+	Scenario: The peer sends a request to "ipc" to execute a RUNCMD command without encryption
 		The peer should recieve a response back.
 
 		Given I start naemon with merlin nodes connected
 			| type   | name        | port |
 			| peer   | my_peer     | 4123 |
+		And I wait for 1 second
+
+		Then my_peer is connected to merlin
+		When my_peer sends event RUNCMD_PACKET
+			| sd      | 29		 							       |
+			| content | command.name=test_command;command.command_line=echo OK;runcmd=test_command |
+		And I wait for 4 second
+
+		Then file merlin.log matches RUNCMD: Can only accept runcmds over encrypted connections
+
+
+	@encrypted
+	Scenario: The peer sends a request to "ipc" to execute a RUNCMD without accept_runcmd set
+		The peer should recieve a response back.
+
+		Given I start naemon with merlin nodes connected
+			| type   | name        | port |
+			| peer   | my_peer     | 4123 |
+		And I wait for 1 second
+
+		Then my_peer is connected to merlin
+		When my_peer sends event RUNCMD_PACKET
+			| sd      | 29		 							       |
+			| content | command.name=test_command;command.command_line=echo OK;runcmd=test_command |
+		And I wait for 4 second
+
+		Then file merlin.log matches RUNCMD: accept_runcmd config setting not set for this node
+
+
+	@encrypted
+	Scenario: The peer sends a request to "ipc" to execute a RUNCMD with accept_runcmd set
+		The peer should recieve a response back.
+
+		Given I start naemon with merlin nodes connected
+			| type   | name        | port | accept_runcmd |
+			| peer   | my_peer     | 4123 | 1             |
 		And I wait for 1 second
 
 		Then my_peer is connected to merlin

--- a/module/queries.c
+++ b/module/queries.c
@@ -133,6 +133,11 @@ static int remote_runcmd(int sd, char *buf, unsigned int len)
 		return 1;
 	}
 
+	if (node->type == MODE_MASTER) {
+		nsock_printf_nul(sd, "outstd=Sending commands from pollers is forbidden\n", node->name);
+		return 1;
+	}
+
 	/* Filter away the node name from the command */
 	buf = strchr(buf, ';');
 	if (buf == NULL) {

--- a/module/runcmd.c
+++ b/module/runcmd.c
@@ -53,6 +53,24 @@ void runcmd_wproc_callback(wproc_result *wpres, void * arg, int flags) {
 
 int handle_runcmd_event(merlin_node *node, merlin_event *pkt) {
 	if (pkt->hdr.code == RUNCMD_CMD) {
+
+		/* Validate that we are allowed to recieve this cmd */
+		// Check that we are encrypted
+		if(!node->encrypted) {
+			lwarn("RUNCMD: Can only accept runcmds over encrypted connections");
+			return 0;
+		}
+		// Check that sender is either master or peer
+		if((node->type != MODE_PEER) && (node->type != MODE_MASTER)) {
+			lwarn("RUNCMD: Can only accept runcmds from Masters or Peers");
+			return 0;
+		}
+		// Check that accept_runcmd is set
+		if (!node->accept_runcmd) {
+			lwarn("RUNCMD: accept_runcmd config setting not set for this node");
+			return 0;
+		}
+
 		/* Execute and return send RESP packet back */
 		runcmd_ctx * ctx;
 		merlin_runcmd * runcmd = (merlin_runcmd *) pkt->body;

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -45,7 +45,8 @@ post:
     fi
 
     cucumber \${VERBOSE:+-v} --strict --format html \
-        --out /mnt/logs/cucumber.html --format pretty
+        --out /mnt/logs/cucumber.html --format pretty\
+        --tags ~@encrypted
     # Run the test suite again, but with encryption enabled
     # Some tests has been disabled. These tests pass just fine when running the
     # test suite with encryption enabled only, but for some reason fail when
@@ -58,4 +59,4 @@ post:
     export MERLIN_PRIVKEY=/opt/monitor/op5/merlin/key.priv
     cucumber \${VERBOSE:+-v} --strict --format html \
         --out /mnt/logs/cucumber_encrypted.html \
-        --format pretty --exclude "report_data" --tags ~@unstable
+        --format pretty --exclude "report_data" --tags ~@unstable --tags ~@unencrypted

--- a/shared/node.c
+++ b/shared/node.c
@@ -538,6 +538,14 @@ static void grok_node(struct cfg_comp *c, merlin_node *node)
 					cfg_error(c, v, "Illegal value for auto_delete: %s\n", v->value);
 			}
 		}
+		else if (!strcmp(v->key, "accept_runcmd")) {
+			int value = atoi(v->value);
+			if (value == 1) {
+				node->accept_runcmd = true;
+			} else {
+				node->accept_runcmd = false;
+			}
+		}
 		else if (grok_node_flag(&node->flags, v->key, v->value) < 0) {
 			cfg_error(c, v, "Unknown variable\n");
 		}

--- a/shared/node.h
+++ b/shared/node.h
@@ -268,6 +268,7 @@ struct merlin_node {
 	bool incompatible_cluster_config;
 	unsigned int auto_delete;
 	objectlist *ipc_blocked_hostgroups;       /* only used for IPC */
+	bool accept_runcmd;
 };
 
 struct merlin_runcmd {


### PR DESCRIPTION
With this commit we introduce a new node setting called accept_runcmd.
This setting must be enabled on the nodes from which we want to accept
runcmds, in addition to having encryption enabled. This enables us to
set up encrypted nodes without per default also accepting runcmds from
those nodes. This commit also introduces safety checks in order to make
sure we're not accepting or sending runcmds from pollers.

Fixes: MON-13148
Signed-off-by: Erik Sjöström <esjostrom@itrsgroup.com>