### PR TITLE
Bugfix/version pin multi test gem

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -26,14 +26,20 @@ post:
 
     # Install requirements for cucumber test
     gem install --no-ri --no-rdoc \
-        cucumber:1.3.18 \
         multi_test:0.1.2 \
+        cucumber:1.3.18 \
         rspec:2.14.1 \
         parallel:1.13.0 \
         parallel_tests:2.23.0 \
         syntax:1.0.0 \
         sequel \
         mysql2
+
+    # Uninstall unwanted dependency gems from cucumber installation.
+    # Todo: We should upgrade cucumber to version 3.2.0 so that we use the same
+    # version throughout our repos.
+    gem uninstall multi_test:1.0.0
+
 
     # Run cucumber tests
     ulimit -c unlimited

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -27,6 +27,7 @@ post:
     # Install requirements for cucumber test
     gem install --no-ri --no-rdoc \
         cucumber:1.3.18 \
+        multi_test:0.1.2 \
         rspec:2.14.1 \
         parallel:1.13.0 \
         parallel_tests:2.23.0 \

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -38,7 +38,7 @@ post:
     # Uninstall unwanted dependency gems from cucumber installation.
     # Todo: We should upgrade cucumber to version 3.2.0 so that we use the same
     # version throughout our repos.
-    gem uninstall multi_test:1.0.0
+    gem uninstall multi_test -v 1.0.0
 
 
     # Run cucumber tests


### PR DESCRIPTION
On May the 5:th an updated version of the gem `multi_test` (version 1.0.0) was released and broke our builds of `monitor-livestatus` and `monitor-merlin`. See https://github.com/cucumber/multi_test/issues/26 . 

Both of these repos use an older version of `cucumber` then the rest of our repos. So we should update to use the same version across all repos. But before we do that we thought that we should do a quick fix and just version pin the gem to the previous version.

Unfortunately it did not work just to pin a specific version of the multi_test gem. The gem is a run time dependency of cucumber and when installing `multi_test:0.1.2` before installing `cucumber` did not make any difference. Installation of `cucumber` always lead to the installation of the latest `multi_test` gem, version 1.0.0. According documentation it should be possible to install with `--conservative` or `--minimal-deps` which should not attempt to upgrade/don't upgrade gems already meeting version requirements. But nor:
`gem install multi_test:0.1.2; gem install --conservative cucumber:1.3.8`
or
`gem install multi_test:0.1.2; gem install --minimal-deps cucumber:1.3.8`
worked.

So we ended up with a rather ugly hack of first installing the version of multi_test we wanted, then installing cucumber and then un-installing the unwanted multi_test version.