### PR TITLE
Revert "Make sure to use specific version of multi_test gem"

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -26,7 +26,6 @@ post:
 
     # Install requirements for cucumber test
     gem install --no-ri --no-rdoc \
-        multi_test:0.1.2 \
         cucumber:1.3.18 \
         rspec:2.14.1 \
         parallel:1.13.0 \
@@ -34,12 +33,6 @@ post:
         syntax:1.0.0 \
         sequel \
         mysql2
-
-    # Uninstall unwanted dependency gems from cucumber installation.
-    # Todo: We should upgrade cucumber to version 3.2.0 so that we use the same
-    # version throughout our repos.
-    gem uninstall multi_test -v 1.0.0
-
 
     # Run cucumber tests
     ulimit -c unlimited


### PR DESCRIPTION
Version 1.1.0 of multi_test re-adds the disable_autorun feature.

This reverts commit 493832e016c0948f74d81bd1b8e85a160f1a9f22.