### PR TITLE
Add --all-nodes option to showlog

### DIFF
--- a/tools/logutils.h
+++ b/tools/logutils.h
@@ -56,6 +56,11 @@ struct string_code {
 	int code;
 };
 
+struct err_message{
+	char *message;
+	struct err_message *next;
+};
+
 extern int logs_debug_level;
 extern int num_nfile;
 extern struct naglog_file *cur_file; /* the file we're currently importing */


### PR DESCRIPTION
This commit adds a new command line option --all-nodes to the
showlog tool. This new option will gather logs from all nodes
and create a consolidated list of event logs. Each log is
appended with the node name where the log originated.

This is part of MON-13186

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>