### PR TITLE
Fix order of deinit

### DIFF
--- a/tests/test-hooks.c
+++ b/tests/test-hooks.c
@@ -112,11 +112,11 @@ static void expiration_setup(void)
 
 static void expiration_teardown(void)
 {
-	destroy_objects_host();
 	destroy_objects_service(TRUE);
+	destroy_objects_host();
+	nebmodule_deinit(0, 0);
 	qh_deinit(queryhandler_socket_path);
 	iobroker_destroy(nagios_iobs, IOBROKER_CLOSE_SOCKETS);
-	nebmodule_deinit(0, 0);
 }
 
 #define to_timed_event(user_data) \


### PR DESCRIPTION
This commit fixes order of test deinitialization based on the reverse order that the resurces were allocated in test initilization. Based on valgrind tests, the nebmodule_deinit was reading from invalid memory area. Fixing this removed the invalid reads.

This resolves MON-13318.