### PR TITLE
install mysql2 first before other requirements

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -17,13 +17,13 @@ post:
 
     # Install requirements for cucumber test
     gem install --no-ri --no-rdoc \
+        mysql2 \
         cucumber:1.3.18 \
         rspec:2.14.1 \
         parallel:1.13.0 \
         parallel_tests:2.23.0 \
         syntax:1.0.0 \
-        sequel \
-        mysql2
+        sequel
 
     # Run cucumber tests
     ulimit -c unlimited


### PR DESCRIPTION
This commit installs mysql2 first to avoid version compatibility issue.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>