### PR TITLE
Add nrpe as sudoer for asmonitor

### DIFF
--- a/sudo/merlin.in
+++ b/sudo/merlin.in
@@ -14,4 +14,8 @@ Cmnd_Alias      MON_OPERATOR =  /usr/bin/mon node,\
         /usr/bin/mon stop,\
         /usr/bin/mon restart
 
+Cmnd_Alias      SELF_MON_CMDS =  /usr/bin/mon check *,\
+        /opt/plugins/check_op5_license
+
 %mon_operators  ALL = (ALL) NOPASSWD: MON_OPERATOR
+%nrpe  ALL = (@naemon_user@) NOPASSWD: SELF_MON_CMDS


### PR DESCRIPTION
This commit adds NRPE as sudoer for asmonitor to enable NRPE style self monitoring checks.

This resolves MON-13311.