### PR TITLE
Pin Sequel Gem

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -23,7 +23,7 @@ post:
         parallel:1.13.0 \
         parallel_tests:2.23.0 \
         syntax:1.0.0 \
-        sequel
+        sequel:5.71.0
 
     # Run cucumber tests
     ulimit -c unlimited


### PR DESCRIPTION
This commit pins sequel gem to 5.71.0 due to errors encoutered using the latest version.

This fixes MON-13347.