### PR TITLE
Limit logs from nodes when all-nodes parameter is used

### DIFF
--- a/tests/test-showlog.c
+++ b/tests/test-showlog.c
@@ -406,6 +406,44 @@ START_TEST (select_single_service)
 }
 END_TEST
 
+START_TEST (use_limit)
+{
+	//include no =(equal) handling in --first and --last parameter
+	char *args[] = {
+		NULL,
+		"tests/showlog_test.log",
+		"--show-all",
+		"--first",
+		"1386686225",
+		"--last",
+		"1412770876",
+		"--ascii",
+		"--time-format=raw",
+		"--host=monitor",
+		"--hide-process",
+		"--hide-command",
+		"--limit=1",
+		NULL
+	};
+	char *actual;
+	int diff;
+	FILE *fd = fopen("tests/showlog_test_monitoronly.log", "r");
+	char expected[6000];
+
+	//Expected one line only
+	if (fgets(expected, sizeof(expected), fd) == NULL){
+		ck_abort_msg("Could not read from expected log");
+	}
+
+	actual = run_with(args, NULL);
+	if ((diff = strcmp(expected, actual))) {
+		ck_abort_msg("showlog didn't return the input. It looked like %s", actual);
+	}
+	free(actual);
+}
+END_TEST
+
+
 Suite *
 showlog_suite(void)
 {
@@ -431,6 +469,7 @@ showlog_suite(void)
   tcase_add_test(log_selection, none);
   tcase_add_test(log_selection, select_single_host);
   tcase_add_test(log_selection, select_single_service);
+  tcase_add_test(log_selection, use_limit);
   suite_add_tcase(s, log_selection);
 
   return s;

--- a/tools/showlog.c
+++ b/tools/showlog.c
@@ -28,9 +28,10 @@ static int count;
 static unsigned long printed_lines;
 static int restrict_objects = 0;
 static int all_nodes = 0;
-static const char all_node_command_string[] = "asmonitor mon node ctrl %s -- mon log show --time-format=raw --first=%d --last=%d";
+static const char all_node_command_string[] = "asmonitor mon node ctrl %s -- mon log show --time-format=raw --first=%d --last=%d --limit=%llu";
 static const char all_node_log_warning[] = "showlog: No log from %s. Check connectivity or maybe this is a passive poller";
-static const int max_epoch_len = 11;
+static const int max_epoch_len = 11; /* max characters of largest epoch number*/
+static const int max_llu_len = 21; /* max characters of largest unsigned long long*/
 
 
 #define all_node_tmp_dir "/opt/monitor/var"
@@ -1093,7 +1094,7 @@ static int processAllNodes(void)
 				ret = -1;
 				break;
 			}
-			pCommand = realloc (pCommand, szNodeName + sizeof(all_node_command_string) + max_epoch_len * 2);
+			pCommand = realloc (pCommand, szNodeName + sizeof(all_node_command_string) + max_epoch_len * 2 + max_llu_len);
 			if (pCommand == NULL) {
 				warn("Failed to allocate memory\n");
 				ret = -1;
@@ -1101,7 +1102,7 @@ static int processAllNodes(void)
 			}
 		}
 		sscanf(pNode, "%s", pNodeName); //remove spaces from the node name
-		sprintf(pCommand, all_node_command_string, pNodeName, first_time, last_time);
+		sprintf(pCommand, all_node_command_string, pNodeName, first_time, last_time, limit);
 		ret = processNodeLogs(pCommand, pNodeName);
 	}
 	//close and free
@@ -1112,8 +1113,8 @@ static int processAllNodes(void)
 
 	//Process local logs
 	if (ret == 0){
-		char aCommand[100];
-		sprintf(aCommand, "asmonitor mon log show --time-format=raw --first=%d --last=%d", first_time, last_time);
+		char aCommand[200];
+		sprintf(aCommand, "asmonitor mon log show --time-format=raw --first=%d --last=%d --limit=%llu", first_time, last_time, limit);
 		ret = processNodeLogs(aCommand, "local");
 	}
 


### PR DESCRIPTION
This commit uses the provided --first, --last and --limit parameter values
from the command line to extract logs from all nodes based on a limit
instead of extracting all logs. This will reduce the disk space usage
since Ninja will display 7 days by default.

This is part of MON-13363.

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>