### PR TITLE
Install requirements for tests using gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+ruby '~> 2.5.0'
+
+gem 'mysql2', '~> 0.5.2'
+gem 'cucumber', '1.3.18'
+gem 'rspec', '2.14.1'
+gem 'parallel', '1.19.2'
+gem 'parallel_tests', '2.32.0'
+gem 'syntax', '1.0.0'
+gem 'sequel', '5.71.0'

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -18,14 +18,8 @@ post:
     stat --printf='%U:%G %a' /opt/monitor/op5/merlin/merlin.conf | xargs -I{} test "root:apache 660" = "{}"
 
     # Install requirements for cucumber test
-    gem install --no-ri --no-rdoc \
-        mysql2 \
-        cucumber:1.3.18 \
-        rspec:2.14.1 \
-        parallel:1.13.0 \
-        parallel_tests:2.23.0 \
-        syntax:1.0.0 \
-        sequel:5.71.0
+    gem install --no-ri --no-rdoc bundler -v '~> 2.3.0'
+    bundle install
 
     # Run cucumber tests
     ulimit -c unlimited


### PR DESCRIPTION
This commit moves the gem install using gemfile
to fix encountered issue when installing
parallel_tests.
This also updates parallel and parallel_tests
version to latest versions that supports ruby
v2.5.0.

This resolves MON-13444.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>