### PR TITLE
Upgrade to ruby 2.7

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -17,8 +17,15 @@ post:
     # Verify file permissions after installation
     stat --printf='%U:%G %a' /opt/monitor/op5/merlin/merlin.conf | xargs -I{} test "root:apache 660" = "{}"
 
+    gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    curl -sSL https://get.rvm.io | bash -s stable
+    source /usr/local/rvm/scripts/rvm
+    rvm install 2.7
+    rvm use 2.7 --default
+    ruby -v
+
     # Install requirements for cucumber test
-    gem install --no-ri --no-rdoc \
+    gem install \
         mysql2 \
         cucumber:1.3.18 \
         rspec:2.14.1 \


### PR DESCRIPTION
Ths commit upgrades ruby to 2.7 to fix issues in gem installation of parallel_tests.

This resolves MON-13444.