### PR TITLE
Remove deprecated cmp() in merlin apps

### DIFF
--- a/apps/libexec/modules/merlin_qh.py
+++ b/apps/libexec/modules/merlin_qh.py
@@ -17,14 +17,14 @@ def get_merlin_nodeinfo(query_handler):
 
 def get_expired(query_handler):
 	def expired_cmp(a, b):
-		res = cmp(a['responsible'], b['responsible']) or cmp(a['responsible'], b['responsible'])
+		res = (a['responsible'] > b['responsible']) - (a['responsible'] < b['responsible'])
 		if res:
 			return res
 		if not a.get('service_description'):
 			return -1
 		if not b.get('service_description'):
 			return 1
-		return a['service_description'] > b['service_description']
+		return (a['service_description'] > b['service_description']) - (a['service_description'] < b['service_description'])
 	qh = nagios_qh.nagios_qh(query_handler)
 	expired = []
 	for info in qh.get('#merlin expired\0'):

--- a/apps/libexec/tests/test_merlin_qh.py
+++ b/apps/libexec/tests/test_merlin_qh.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+from unittest.mock import MagicMock
+
+sys.path.append('modules')
+
+from modules.merlin_qh import get_expired 
+
+class merlin_qh_test(unittest.TestCase):
+    @patch('nagios_qh.nagios_qh')  
+    def test_get_expired(self, mock_nagios_qh):
+        # Configure the mock to return a specific value if needed
+        mock_nagios_qh.return_value = MagicMock()
+        mock_nagios_qh.return_value.get.return_value = [
+            {
+                'host_name': 'example_host',
+                'service_description': 'example_service02',
+                'added': 'example_date',
+                'responsible': 'peer02'
+            },
+            {
+                'host_name': 'example_host',
+                'service_description': 'example_service01',
+                'added': 'example_date',
+                'responsible': 'peer02'
+            },
+            {
+                'host_name': 'example_host',
+                'added': 'example_date',
+                'responsible': 'peer02'
+            },
+            {
+                'host_name': 'example_host',
+                'added': 'example_date',
+                'responsible': 'peer01'
+            },
+            {
+                'host_name': 'example_host',
+                'service_description': 'example_service03',
+                'added': 'example_date',
+                'responsible': 'peer01'
+            },
+        ]
+
+        expected = [
+            {
+                'host_name': 'example_host',
+                'added': 'example_date',
+                'responsible': 'peer01'
+            },
+            {
+                'host_name': 'example_host',
+                'service_description': 'example_service03',
+                'added': 'example_date',
+                'responsible': 'peer01'
+            },
+            {
+                'host_name': 'example_host',
+                'added': 'example_date',
+                'responsible': 'peer02'
+            },
+            {
+                'host_name': 'example_host',
+                'service_description': 'example_service01',
+                'added': 'example_date',
+                'responsible': 'peer02'
+            },
+            {
+                'host_name': 'example_host',
+                'service_description': 'example_service02',
+                'added': 'example_date',
+                'responsible': 'peer02'
+            },
+        ]
+
+        # Call the function you're testing
+        result = get_expired("mockedvalue")
+
+        # Assert that nagios_qh.nagios_qh was called with the expected arguments
+        mock_nagios_qh.assert_called_once_with('mockedvalue')  # Replace with the actual argument
+
+        # Further assertions depending on what my_function does and what you expect
+        self.assertEqual(result, expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit update the 'mon check distribution' command to remove the deprecated python2 cmp() function for python3 comparison operators. It also adjusts comparison for 'service description' fields to be similar to comparison used in the 'responsible' fields.

Unit testing was also added for affected python function.

This resolves MON-13481.