### PR TITLE
Pinned multi_json version for el7

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -26,11 +26,12 @@ post:
 
     # Install requirements for cucumber test
     gem install --no-ri --no-rdoc \
-        cucumber:1.3.18 \
+        multi_json:1.15.0 \
         rspec:2.14.1 \
         parallel:1.13.0 \
         parallel_tests:2.23.0 \
         syntax:1.0.0 \
+        cucumber:1.3.18 \
         sequel \
         mysql2
 


### PR DESCRIPTION
Pinned multi_json version to ensure compatibility 
with ruby version 2.7. Multi_json is needed by rspec 
that is used in cucumber test scripts.

This is part of MON-13581

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>